### PR TITLE
Provision Linux containers and PCAP capture for AC-0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,10 +68,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -71,10 +148,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -123,6 +224,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,10 +279,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -162,6 +362,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -185,10 +391,270 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -203,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +685,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -231,6 +713,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
@@ -260,12 +748,31 @@ name = "multifold"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bollard",
+ "chrono",
  "clap",
+ "futures-util",
+ "ipnet",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -281,10 +788,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -321,6 +855,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,10 +888,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "semver"
@@ -389,17 +973,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -410,6 +1041,34 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -429,6 +1088,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +1112,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +1183,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys",
 ]
@@ -466,6 +1198,50 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -486,10 +1262,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -516,6 +1319,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -545,8 +1393,65 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -554,6 +1459,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -592,7 +1515,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -623,7 +1546,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -642,7 +1565,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -650,6 +1573,89 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
+bollard = "0.18"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+futures-util = "0.3"
+ipnet = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/scenarios/ac-0-expected/meta.json
+++ b/scenarios/ac-0-expected/meta.json
@@ -20,13 +20,13 @@
       "name": "attacker-001",
       "os": "linux",
       "role": "attacker",
-      "ip": "10.100.0.2"
+      "ips": ["10.100.0.2"]
     },
     {
       "name": "target-001",
       "os": "linux",
       "role": "target",
-      "ip": "10.100.0.3"
+      "ips": ["10.100.0.3"]
     }
   ],
   "network": {
@@ -38,6 +38,11 @@
     ]
   },
   "capture": {
-    "pcap": "net/capture.pcap"
+    "pcaps": [
+      {
+        "segment": "lan",
+        "path": "net/capture-lan.pcap"
+      }
+    ]
   }
 }

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -1,0 +1,637 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::Hasher;
+use std::net::Ipv4Addr;
+use std::path::Path;
+
+use anyhow::{Context, Result, ensure};
+use bollard::Docker;
+use bollard::container::{
+    Config, CreateContainerOptions, NetworkingConfig, RemoveContainerOptions,
+};
+use bollard::image::CreateImageOptions;
+use bollard::models::{EndpointIpamConfig, EndpointSettings, HostConfig, Ipam, IpamConfig};
+use bollard::network::{ConnectNetworkOptions, CreateNetworkOptions};
+use futures_util::TryStreamExt;
+use ipnet::Ipv4Net;
+
+use crate::scenario::Scenario;
+
+const CAPTURE_IMAGE: &str = "alpine:3.19";
+const LINUX_IFNAMSIZ: usize = 15;
+
+/// Holds provisioned Docker resources and assigned host IPs.
+///
+/// Each entry in `host_ips` maps a host name to **all** IPs assigned
+/// across every segment the host belongs to (primary first).
+pub(crate) struct ProvisionedEnv {
+    docker: Docker,
+    network_ids: Vec<String>,
+    container_ids: Vec<String>,
+    pub(crate) host_ips: Vec<(String, Vec<Ipv4Addr>)>,
+}
+
+/// Per-segment state accumulated during provisioning.
+struct SegmentInfo {
+    net_name: String,
+    bridge: String,
+    ips: Vec<(String, Ipv4Addr)>,
+}
+
+/// Assigns IPs to hosts within a CIDR subnet.
+///
+/// Skips the network address (.0) and gateway (.1), assigning from .2
+/// onward. Returns the gateway IP and host-to-IP pairs.
+pub(crate) fn assign_ips(
+    subnet: &str,
+    hosts: &[String],
+) -> Result<(Ipv4Addr, Vec<(String, Ipv4Addr)>)> {
+    let net: Ipv4Net = subnet
+        .parse()
+        .with_context(|| format!("invalid subnet CIDR: {subnet}"))?;
+    let base = u32::from(net.network());
+    let broadcast = u32::from(net.broadcast());
+    let gateway = Ipv4Addr::from(base + 1);
+    let mut ips = Vec::with_capacity(hosts.len());
+    for (i, host) in hosts.iter().enumerate() {
+        let offset = u32::try_from(i + 2).context("too many hosts for subnet IP assignment")?;
+        let addr = base + offset;
+        ensure!(
+            addr < broadcast,
+            "subnet {subnet} has no room for host '{host}' \
+             (need {} addresses, only {} usable)",
+            hosts.len(),
+            broadcast - base - 2,
+        );
+        let ip = Ipv4Addr::from(addr);
+        ips.push((host.clone(), ip));
+    }
+    Ok((gateway, ips))
+}
+
+/// Derives a Linux bridge interface name that fits within `IFNAMSIZ`.
+fn bridge_name(prefix: &str, segment: &str) -> String {
+    let candidate = format!("mf-{prefix}-{segment}");
+    if candidate.len() <= LINUX_IFNAMSIZ {
+        return candidate;
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write(candidate.as_bytes());
+    format!("mf-{:011x}", hasher.finish() & 0xFFF_FFFF_FFFF)
+}
+
+/// Generates a short, per-run identifier to avoid Docker name collisions
+/// across concurrent runs of the same scenario.
+fn generate_run_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    h.write_u128(nanos);
+    h.write_u32(std::process::id());
+    // Intentionally truncate: we only need 32 bits of entropy for
+    // a short collision-resistant suffix, not a full 64-bit hash.
+    #[allow(clippy::cast_possible_truncation)]
+    let short = h.finish() as u32;
+    format!("{short:08x}")
+}
+
+impl ProvisionedEnv {
+    /// Provisions Docker networks, containers, and capture sidecars
+    /// for each network segment in the scenario.
+    pub(crate) async fn up(scenario: &Scenario, pcap_dir: &Path) -> Result<Self> {
+        let docker =
+            Docker::connect_with_local_defaults().context("failed to connect to Docker daemon")?;
+        docker
+            .ping()
+            .await
+            .context("Docker daemon is not reachable — is Docker running?")?;
+
+        let mut env = Self {
+            docker,
+            network_ids: Vec::new(),
+            container_ids: Vec::new(),
+            host_ips: Vec::new(),
+        };
+
+        let run_id = generate_run_id();
+        if let Err(e) = env.setup(scenario, pcap_dir, &run_id).await {
+            let _ = env.teardown_inner().await;
+            return Err(e);
+        }
+
+        Ok(env)
+    }
+
+    /// Tears down all provisioned Docker resources.
+    pub(crate) async fn down(self) -> Result<()> {
+        self.teardown_inner().await
+    }
+
+    async fn setup(&mut self, scenario: &Scenario, pcap_dir: &Path, run_id: &str) -> Result<()> {
+        let prefix = format!("{}-{run_id}", scenario.metadata.name);
+        let mut pulled: HashSet<String> = HashSet::new();
+
+        // Phase 1: Create Docker networks and compute IP assignments.
+        let mut segments: Vec<SegmentInfo> = Vec::new();
+        for seg in &scenario.infrastructure.network.segments {
+            let (gateway, seg_ips) = assign_ips(&seg.subnet, &seg.hosts)?;
+            let net_name = format!("mf-{prefix}-{}", seg.name);
+            let bridge = bridge_name(&prefix, &seg.name);
+            let network_id =
+                create_network(&self.docker, &net_name, &seg.subnet, gateway, &bridge).await?;
+            self.network_ids.push(network_id);
+            segments.push(SegmentInfo {
+                net_name,
+                bridge,
+                ips: seg_ips,
+            });
+        }
+
+        // Phase 2: Create host containers (once each) and connect
+        // multi-homed hosts to additional networks.
+        let mut created: HashMap<String, String> = HashMap::new();
+        for state in &segments {
+            for (host_name, ip) in &state.ips {
+                if let Some(container_id) = created.get(host_name) {
+                    connect_container(&self.docker, &state.net_name, container_id, *ip).await?;
+                    // Record the secondary IP for this multi-homed host.
+                    if let Some((_, ips)) =
+                        self.host_ips.iter_mut().find(|(name, _)| name == host_name)
+                    {
+                        ips.push(*ip);
+                    }
+                } else {
+                    let host = scenario
+                        .infrastructure
+                        .hosts
+                        .iter()
+                        .find(|h| h.name == *host_name)
+                        .with_context(|| format!("host '{host_name}' not in scenario"))?;
+
+                    if pulled.insert(host.image.clone()) {
+                        pull_image(&self.docker, &host.image).await?;
+                    }
+
+                    let container_name = format!("mf-{prefix}-{host_name}");
+                    let id = create_host_container(
+                        &self.docker,
+                        &container_name,
+                        &host.image,
+                        &state.net_name,
+                        &ip.to_string(),
+                    )
+                    .await?;
+                    self.docker
+                        .start_container::<String>(&id, None)
+                        .await
+                        .with_context(|| format!("failed to start container '{container_name}'"))?;
+                    self.container_ids.push(id.clone());
+                    created.insert(host_name.clone(), id);
+                    self.host_ips.push((host_name.clone(), vec![*ip]));
+                }
+            }
+        }
+
+        // Phase 3: Start per-segment capture containers.
+        // Each runs on the host network and captures the bridge interface
+        // so it observes all unicast traffic between hosts.
+        if pulled.insert(CAPTURE_IMAGE.to_owned()) {
+            pull_image(&self.docker, CAPTURE_IMAGE).await?;
+        }
+        for (state, seg) in segments
+            .iter()
+            .zip(&scenario.infrastructure.network.segments)
+        {
+            let pcap_file = format!("capture-{}.pcap", seg.name);
+            let capture_name = format!("mf-{prefix}-{}-capture", seg.name);
+            let capture_id = create_capture_container(
+                &self.docker,
+                &capture_name,
+                &state.bridge,
+                pcap_dir,
+                &pcap_file,
+            )
+            .await?;
+            self.docker
+                .start_container::<String>(&capture_id, None)
+                .await
+                .context("failed to start capture container")?;
+            self.container_ids.push(capture_id);
+        }
+
+        Ok(())
+    }
+
+    async fn teardown_inner(&self) -> Result<()> {
+        let opts = RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        };
+        for id in &self.container_ids {
+            let _ = self.docker.stop_container(id, None).await;
+            let _ = self.docker.remove_container(id, Some(opts)).await;
+        }
+        for id in &self.network_ids {
+            let _ = self.docker.remove_network(id).await;
+        }
+        Ok(())
+    }
+}
+
+async fn pull_image(docker: &Docker, image: &str) -> Result<()> {
+    let (repo, tag) = image.split_once(':').unwrap_or((image, "latest"));
+    let opts = CreateImageOptions {
+        from_image: repo,
+        tag,
+        ..Default::default()
+    };
+    docker
+        .create_image(Some(opts), None, None)
+        .try_collect::<Vec<_>>()
+        .await
+        .with_context(|| format!("failed to pull image '{image}'"))?;
+    Ok(())
+}
+
+async fn create_network(
+    docker: &Docker,
+    name: &str,
+    subnet: &str,
+    gateway: Ipv4Addr,
+    bridge: &str,
+) -> Result<String> {
+    let options = HashMap::from([(
+        String::from("com.docker.network.bridge.name"),
+        bridge.to_owned(),
+    )]);
+    let config = CreateNetworkOptions {
+        name: name.to_owned(),
+        driver: String::from("bridge"),
+        options,
+        ipam: Ipam {
+            config: Some(vec![IpamConfig {
+                subnet: Some(subnet.to_owned()),
+                gateway: Some(gateway.to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let response = docker
+        .create_network(config)
+        .await
+        .with_context(|| format!("failed to create network '{name}'"))?;
+    Ok(response.id)
+}
+
+async fn create_host_container(
+    docker: &Docker,
+    name: &str,
+    image: &str,
+    network: &str,
+    ip: &str,
+) -> Result<String> {
+    let mut endpoints = HashMap::new();
+    endpoints.insert(
+        network.to_owned(),
+        EndpointSettings {
+            ipam_config: Some(EndpointIpamConfig {
+                ipv4_address: Some(ip.to_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    let config = Config {
+        image: Some(image.to_owned()),
+        cmd: Some(vec!["sleep".to_owned(), "infinity".to_owned()]),
+        networking_config: Some(NetworkingConfig::<String> {
+            endpoints_config: endpoints,
+        }),
+        ..Default::default()
+    };
+    let opts = CreateContainerOptions {
+        name: name.to_owned(),
+        ..Default::default()
+    };
+    let response = docker
+        .create_container(Some(opts), config)
+        .await
+        .with_context(|| format!("failed to create container '{name}'"))?;
+    Ok(response.id)
+}
+
+/// Connects an existing container to an additional Docker network.
+async fn connect_container(
+    docker: &Docker,
+    network: &str,
+    container_id: &str,
+    ip: Ipv4Addr,
+) -> Result<()> {
+    let config = ConnectNetworkOptions {
+        container: container_id.to_owned(),
+        endpoint_config: EndpointSettings {
+            ipam_config: Some(EndpointIpamConfig {
+                ipv4_address: Some(ip.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    };
+    docker
+        .connect_network(network, config)
+        .await
+        .with_context(|| format!("failed to connect container to network '{network}'"))?;
+    Ok(())
+}
+
+/// Creates a capture container that runs tcpdump on a bridge interface.
+///
+/// Uses host networking so the container can see the Linux bridge
+/// created by Docker, capturing all unicast traffic between hosts.
+async fn create_capture_container(
+    docker: &Docker,
+    name: &str,
+    bridge_iface: &str,
+    pcap_dir: &Path,
+    pcap_filename: &str,
+) -> Result<String> {
+    let pcap_abs = std::fs::canonicalize(pcap_dir)
+        .with_context(|| format!("failed to resolve pcap dir: {}", pcap_dir.display()))?;
+    let bind = format!("{}:/capture", pcap_abs.display());
+
+    let config = Config {
+        image: Some(CAPTURE_IMAGE.to_owned()),
+        cmd: Some(vec![
+            "/bin/sh".to_owned(),
+            "-c".to_owned(),
+            format!(
+                "apk add --no-cache tcpdump >/dev/null 2>&1 && \
+                 exec tcpdump -i {bridge_iface} -w /capture/{pcap_filename} -U"
+            ),
+        ]),
+        host_config: Some(HostConfig {
+            binds: Some(vec![bind]),
+            cap_add: Some(vec!["NET_RAW".to_owned(), "NET_ADMIN".to_owned()]),
+            network_mode: Some(String::from("host")),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let opts = CreateContainerOptions {
+        name: name.to_owned(),
+        ..Default::default()
+    };
+    let response = docker
+        .create_container(Some(opts), config)
+        .await
+        .with_context(|| format!("failed to create capture container '{name}'"))?;
+    Ok(response.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── assign_ips tests ──────────────────────────────────────────
+
+    #[test]
+    fn assign_ips_basic() {
+        let hosts = vec!["a".to_owned(), "b".to_owned()];
+        let (gw, ips) = assign_ips("10.100.0.0/24", &hosts).unwrap();
+        assert_eq!(gw, Ipv4Addr::new(10, 100, 0, 1));
+        assert_eq!(ips.len(), 2);
+        assert_eq!(ips[0], ("a".to_owned(), Ipv4Addr::new(10, 100, 0, 2)));
+        assert_eq!(ips[1], ("b".to_owned(), Ipv4Addr::new(10, 100, 0, 3)));
+    }
+
+    #[test]
+    fn assign_ips_single_host() {
+        let hosts = vec!["only".to_owned()];
+        let (gw, ips) = assign_ips("192.168.1.0/24", &hosts).unwrap();
+        assert_eq!(gw, Ipv4Addr::new(192, 168, 1, 1));
+        assert_eq!(ips.len(), 1);
+        assert_eq!(ips[0], ("only".to_owned(), Ipv4Addr::new(192, 168, 1, 2)));
+    }
+
+    #[test]
+    fn assign_ips_invalid_cidr() {
+        let hosts = vec!["h1".to_owned()];
+        let err = assign_ips("not-a-cidr", &hosts).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid subnet CIDR"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn assign_ips_empty_hosts() {
+        let hosts: Vec<String> = vec![];
+        let (gw, ips) = assign_ips("10.0.0.0/24", &hosts).unwrap();
+        assert_eq!(gw, Ipv4Addr::new(10, 0, 0, 1));
+        assert!(ips.is_empty());
+    }
+
+    #[test]
+    fn assign_ips_ac0_scenario() {
+        let hosts = vec!["attacker-001".to_owned(), "target-001".to_owned()];
+        let (gw, ips) = assign_ips("10.100.0.0/24", &hosts).unwrap();
+        assert_eq!(gw, Ipv4Addr::new(10, 100, 0, 1));
+        assert_eq!(
+            ips[0],
+            ("attacker-001".to_owned(), Ipv4Addr::new(10, 100, 0, 2))
+        );
+        assert_eq!(
+            ips[1],
+            ("target-001".to_owned(), Ipv4Addr::new(10, 100, 0, 3))
+        );
+    }
+
+    #[test]
+    fn assign_ips_subnet_overflow() {
+        // /30 gives 4 addresses: .0 (net), .1 (gw), .2 (usable), .3 (broadcast)
+        // Only 1 usable host address, so 2 hosts should fail.
+        let hosts = vec!["a".to_owned(), "b".to_owned()];
+        let err = assign_ips("10.0.0.0/30", &hosts).unwrap_err();
+        assert!(
+            err.to_string().contains("no room"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn assign_ips_subnet_exact_fit() {
+        // /30 = 4 addresses. .0 net, .1 gw, .2 host, .3 broadcast.
+        // Exactly 1 host should fit.
+        let hosts = vec!["a".to_owned()];
+        let (_, ips) = assign_ips("10.0.0.0/30", &hosts).unwrap();
+        assert_eq!(ips.len(), 1);
+        assert_eq!(ips[0].1, Ipv4Addr::new(10, 0, 0, 2));
+    }
+
+    #[test]
+    fn assign_ips_different_subnets() {
+        let hosts = vec!["h1".to_owned()];
+        let (gw, ips) = assign_ips("172.16.5.0/24", &hosts).unwrap();
+        assert_eq!(gw, Ipv4Addr::new(172, 16, 5, 1));
+        assert_eq!(ips[0].1, Ipv4Addr::new(172, 16, 5, 2));
+    }
+
+    // ── bridge_name tests ─────────────────────────────────────────
+
+    #[test]
+    fn bridge_name_short_fits_directly() {
+        assert_eq!(bridge_name("ac-0", "lan"), "mf-ac-0-lan");
+    }
+
+    #[test]
+    fn bridge_name_long_falls_back_to_hash() {
+        let name = bridge_name("very-long-scenario", "segment");
+        assert!(
+            name.len() <= LINUX_IFNAMSIZ,
+            "bridge name '{name}' exceeds {LINUX_IFNAMSIZ} chars",
+        );
+        assert!(name.starts_with("mf-"));
+    }
+
+    #[test]
+    fn bridge_name_is_deterministic() {
+        let a = bridge_name("scenario", "seg");
+        let b = bridge_name("scenario", "seg");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn bridge_name_at_exact_limit() {
+        // "mf-abcdef-abcde" = 15 chars, right at IFNAMSIZ.
+        let name = bridge_name("abcdef", "abcde");
+        assert_eq!(name.len(), LINUX_IFNAMSIZ);
+        assert_eq!(name, "mf-abcdef-abcde");
+    }
+
+    // ── generate_run_id tests ─────────────────────────────────────
+
+    #[test]
+    fn run_id_has_expected_length() {
+        let id = generate_run_id();
+        assert_eq!(id.len(), 8, "run_id should be 8 hex chars: {id}");
+    }
+
+    #[test]
+    fn run_ids_are_unique_across_calls() {
+        let a = generate_run_id();
+        // Sleep a tiny bit to ensure different nanos.
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let b = generate_run_id();
+        assert_ne!(a, b, "consecutive run_ids should differ");
+    }
+
+    // ── Docker E2E tests ──────────────────────────────────────────
+
+    fn load_ac0() -> crate::scenario::Scenario {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scenarios")
+            .join("ac-0.scenario.yaml");
+        crate::scenario::load(&path).unwrap()
+    }
+
+    /// Provisions and tears down ac-0 infrastructure — requires Docker.
+    #[tokio::test]
+    #[ignore = "requires Docker daemon"]
+    async fn provision_ac0_assigns_correct_ips() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        let net_dir = dir.path().join("net");
+        std::fs::create_dir_all(&net_dir).unwrap();
+
+        let env = ProvisionedEnv::up(&scenario, &net_dir).await.unwrap();
+
+        assert_eq!(env.host_ips.len(), 2);
+        assert_eq!(env.host_ips[0].0, "attacker-001");
+        assert_eq!(env.host_ips[0].1, vec![Ipv4Addr::new(10, 100, 0, 2)]);
+        assert_eq!(env.host_ips[1].0, "target-001");
+        assert_eq!(env.host_ips[1].1, vec![Ipv4Addr::new(10, 100, 0, 3)]);
+
+        env.down().await.unwrap();
+    }
+
+    /// Verifies containers are reachable after provisioning — requires Docker.
+    #[tokio::test]
+    #[ignore = "requires Docker daemon"]
+    async fn provisioned_containers_have_connectivity() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        let net_dir = dir.path().join("net");
+        std::fs::create_dir_all(&net_dir).unwrap();
+
+        let env = ProvisionedEnv::up(&scenario, &net_dir).await.unwrap();
+
+        // Exec a ping from attacker to target inside the container.
+        let target_ip = env.host_ips[1].1[0].to_string();
+        let exec_config = bollard::exec::CreateExecOptions {
+            cmd: Some(vec!["ping", "-c", "1", "-W", "2", &target_ip]),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            ..Default::default()
+        };
+        let exec = env
+            .docker
+            .create_exec(&env.container_ids[0], exec_config)
+            .await
+            .unwrap();
+        let output = env.docker.start_exec(&exec.id, None).await.unwrap();
+
+        if let bollard::exec::StartExecResults::Attached {
+            output: mut stream, ..
+        } = output
+        {
+            use futures_util::StreamExt;
+            let mut stdout = String::new();
+            while let Some(Ok(chunk)) = stream.next().await {
+                stdout.push_str(&chunk.to_string());
+            }
+            assert!(
+                stdout.contains("1 packets transmitted"),
+                "ping failed: {stdout}",
+            );
+        } else {
+            panic!("expected attached exec output");
+        }
+
+        env.down().await.unwrap();
+    }
+
+    /// Verifies teardown removes all Docker resources — requires Docker.
+    #[tokio::test]
+    #[ignore = "requires Docker daemon"]
+    async fn teardown_removes_containers_and_networks() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        let net_dir = dir.path().join("net");
+        std::fs::create_dir_all(&net_dir).unwrap();
+
+        let env = ProvisionedEnv::up(&scenario, &net_dir).await.unwrap();
+        let container_ids = env.container_ids.clone();
+        let network_ids = env.network_ids.clone();
+        let docker = Docker::connect_with_local_defaults().unwrap();
+
+        env.down().await.unwrap();
+
+        // Verify containers are gone.
+        for id in &container_ids {
+            let result = docker.inspect_container(id, None).await;
+            assert!(
+                result.is_err(),
+                "container {id} still exists after teardown"
+            );
+        }
+        // Verify networks are gone.
+        for id in &network_ids {
+            let result = docker.inspect_network::<String>(id, None).await;
+            assert!(result.is_err(), "network {id} still exists after teardown");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
+use std::fs;
 use std::path::Path;
 use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use chrono::Utc;
 use clap::{Parser, Subcommand};
 
+mod infra;
+mod meta;
 mod scenario;
 
 #[derive(Parser)]
@@ -37,11 +41,12 @@ enum Command {
     },
 }
 
-fn main() -> ExitCode {
+#[tokio::main]
+async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Generate { scenario, output } => generate(&scenario, &output),
+        Command::Generate { scenario, output } => generate(&scenario, &output).await,
         Command::Validate { bundle } => validate(&bundle),
     };
 
@@ -54,16 +59,63 @@ fn main() -> ExitCode {
     }
 }
 
-fn generate(scenario_path: &str, output: &str) -> Result<()> {
+async fn generate(scenario_path: &str, output: &str) -> Result<()> {
     let scenario = scenario::load(Path::new(scenario_path))?;
     println!(
-        "Loaded scenario '{}': {} host(s), {} segment(s), {} normal + {} attack activities → {output}",
+        "Loaded scenario '{}': {} host(s), {} segment(s), {} normal + {} attack activities",
         scenario.metadata.name,
         scenario.infrastructure.hosts.len(),
         scenario.infrastructure.network.segments.len(),
         scenario.activities.normal.len(),
         scenario.activities.attack.len(),
     );
+
+    let start = Utc::now();
+    let output_dir = Path::new(output);
+    create_output_dirs(output_dir, &scenario)?;
+
+    // Provision Docker infrastructure.
+    println!("Provisioning containers…");
+    let net_dir = output_dir.join("net");
+    let env = infra::ProvisionedEnv::up(&scenario, &net_dir).await?;
+    println!(
+        "Provisioned {} container(s) on {} network(s)",
+        env.host_ips.len(),
+        scenario.infrastructure.network.segments.len(),
+    );
+
+    // Derive the scenario filename for meta.json.
+    let scenario_filename = Path::new(scenario_path).file_name().map_or_else(
+        || scenario_path.to_owned(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    let write_result = meta::write(
+        output_dir,
+        &scenario_filename,
+        &scenario,
+        &env.host_ips,
+        start,
+    );
+
+    // Always tear down infrastructure, even if a previous step failed.
+    let teardown_result = env.down().await;
+    write_result?;
+    println!("Wrote meta.json to {output}");
+    teardown_result?;
+    println!("Infrastructure torn down");
+
+    Ok(())
+}
+
+/// Creates the output bundle directory structure.
+fn create_output_dirs(output_dir: &Path, scenario: &scenario::Scenario) -> Result<()> {
+    fs::create_dir_all(output_dir.join("net")).context("failed to create net directory")?;
+    for host in &scenario.infrastructure.hosts {
+        fs::create_dir_all(output_dir.join("host").join(&host.name))
+            .with_context(|| format!("failed to create host directory for '{}'", host.name))?;
+    }
+    fs::create_dir_all(output_dir.join("ground_truth"))
+        .context("failed to create ground_truth directory")?;
     Ok(())
 }
 
@@ -71,4 +123,70 @@ fn generate(scenario_path: &str, output: &str) -> Result<()> {
 fn validate(bundle: &str) -> Result<()> {
     println!("validate: bundle={bundle}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_ac0() -> scenario::Scenario {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scenarios")
+            .join("ac-0.scenario.yaml");
+        scenario::load(&path).unwrap()
+    }
+
+    #[test]
+    fn create_output_dirs_creates_expected_structure() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        create_output_dirs(dir.path(), &scenario).unwrap();
+
+        assert!(dir.path().join("net").is_dir());
+        assert!(dir.path().join("ground_truth").is_dir());
+        assert!(dir.path().join("host/attacker-001").is_dir());
+        assert!(dir.path().join("host/target-001").is_dir());
+    }
+
+    #[test]
+    fn create_output_dirs_is_idempotent() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        create_output_dirs(dir.path(), &scenario).unwrap();
+        create_output_dirs(dir.path(), &scenario).unwrap();
+        assert!(dir.path().join("net").is_dir());
+    }
+
+    /// Full generate flow — requires a running Docker daemon.
+    #[tokio::test]
+    #[ignore = "requires Docker daemon"]
+    async fn generate_ac0_produces_valid_bundle() {
+        let scenario_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scenarios")
+            .join("ac-0.scenario.yaml");
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+
+        generate(scenario_path.to_str().unwrap(), output)
+            .await
+            .unwrap();
+
+        // Verify directory structure.
+        assert!(dir.path().join("net").is_dir());
+        assert!(dir.path().join("ground_truth").is_dir());
+        assert!(dir.path().join("host/attacker-001").is_dir());
+        assert!(dir.path().join("host/target-001").is_dir());
+
+        // Verify meta.json exists and contains correct IPs.
+        let meta_path = dir.path().join("meta.json");
+        assert!(meta_path.exists(), "meta.json was not created");
+        let content = fs::read_to_string(&meta_path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(value["schema_version"], "1");
+        assert_eq!(value["hosts"][0]["name"], "attacker-001");
+        assert_eq!(value["hosts"][0]["ips"][0], "10.100.0.2");
+        assert_eq!(value["hosts"][1]["name"], "target-001");
+        assert_eq!(value["hosts"][1]["ips"][0], "10.100.0.3");
+        assert_eq!(value["network"]["segments"][0]["subnet"], "10.100.0.0/24");
+    }
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,0 +1,271 @@
+use std::fs;
+use std::net::Ipv4Addr;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::scenario::{self, Attacker, Encryption, Os, Role, Scale, Scenario, Threat, Workload};
+
+const SCHEMA_VERSION: &str = "1";
+
+/// Writes `meta.json` into the output directory.
+pub(crate) fn write(
+    output_dir: &Path,
+    scenario_filename: &str,
+    scenario: &Scenario,
+    host_ips: &[(String, Vec<Ipv4Addr>)],
+    start: DateTime<Utc>,
+) -> Result<()> {
+    let meta = build(scenario_filename, scenario, host_ips, start)?;
+    let json = serde_json::to_string_pretty(&meta).context("failed to serialise meta.json")?;
+    let path = output_dir.join("meta.json");
+    fs::write(&path, json).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn build(
+    scenario_filename: &str,
+    scenario: &Scenario,
+    host_ips: &[(String, Vec<Ipv4Addr>)],
+    start: DateTime<Utc>,
+) -> Result<BundleMeta> {
+    let total_duration = scenario::parse_duration(&scenario.duration)?;
+    let end = start + total_duration;
+
+    let hosts: Vec<MetaHost> = host_ips
+        .iter()
+        .map(|(name, ips)| {
+            let host = scenario
+                .infrastructure
+                .hosts
+                .iter()
+                .find(|h| h.name == *name);
+            match host {
+                Some(h) => Ok(MetaHost {
+                    name: name.clone(),
+                    os: h.os,
+                    role: h.role,
+                    ips: ips.iter().map(Ipv4Addr::to_string).collect(),
+                }),
+                None => bail!("host '{name}' not found in scenario"),
+            }
+        })
+        .collect::<Result<_>>()?;
+
+    let segments = scenario
+        .infrastructure
+        .network
+        .segments
+        .iter()
+        .map(|s| MetaSegment {
+            name: s.name.clone(),
+            subnet: s.subnet.clone(),
+        })
+        .collect();
+
+    Ok(BundleMeta {
+        schema_version: SCHEMA_VERSION.to_owned(),
+        scenario: scenario_filename.to_owned(),
+        scenario_version: scenario.version.clone(),
+        generated_at: fmt_time(start),
+        duration: MetaDuration {
+            total: scenario.duration.clone(),
+            actual_start: fmt_time(start),
+            actual_end: fmt_time(end),
+        },
+        environment: MetaEnvironment {
+            scale: scenario.environment.scale,
+            encryption: scenario.environment.encryption,
+            workload: scenario.environment.workload,
+            threat: scenario.environment.threat,
+            attacker: scenario.environment.attacker,
+        },
+        hosts,
+        network: MetaNetwork { segments },
+        capture: MetaCapture {
+            pcaps: scenario
+                .infrastructure
+                .network
+                .segments
+                .iter()
+                .map(|s| MetaPcapEntry {
+                    segment: s.name.clone(),
+                    path: format!("net/capture-{}.pcap", s.name),
+                })
+                .collect(),
+        },
+    })
+}
+
+fn fmt_time(t: DateTime<Utc>) -> String {
+    t.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+#[derive(Debug, Serialize)]
+struct BundleMeta {
+    schema_version: String,
+    scenario: String,
+    scenario_version: String,
+    generated_at: String,
+    duration: MetaDuration,
+    environment: MetaEnvironment,
+    hosts: Vec<MetaHost>,
+    network: MetaNetwork,
+    capture: MetaCapture,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaDuration {
+    total: String,
+    actual_start: String,
+    actual_end: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaEnvironment {
+    scale: Scale,
+    encryption: Encryption,
+    workload: Workload,
+    threat: Threat,
+    attacker: Attacker,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaHost {
+    name: String,
+    os: Os,
+    role: Role,
+    ips: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaNetwork {
+    segments: Vec<MetaSegment>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaSegment {
+    name: String,
+    subnet: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaCapture {
+    pcaps: Vec<MetaPcapEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetaPcapEntry {
+    segment: String,
+    path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type HostIps = Vec<(String, Vec<Ipv4Addr>)>;
+
+    fn ac0_test_inputs() -> (Scenario, HostIps, DateTime<Utc>) {
+        let yaml = include_str!("../scenarios/ac-0.scenario.yaml");
+        let scenario: Scenario = serde_yaml::from_str(yaml).unwrap();
+        let host_ips = vec![
+            (
+                "attacker-001".to_owned(),
+                vec![Ipv4Addr::new(10, 100, 0, 2)],
+            ),
+            ("target-001".to_owned(), vec![Ipv4Addr::new(10, 100, 0, 3)]),
+        ];
+        let start = DateTime::parse_from_rfc3339("2026-01-15T09:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        (scenario, host_ips, start)
+    }
+
+    #[test]
+    fn build_meta_matches_expected_structure() {
+        let (scenario, host_ips, start) = ac0_test_inputs();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+
+        assert_eq!(meta.schema_version, "1");
+        assert_eq!(meta.scenario, "ac-0.scenario.yaml");
+        assert_eq!(meta.scenario_version, "1");
+        assert_eq!(meta.generated_at, "2026-01-15T09:00:00Z");
+        assert_eq!(meta.duration.total, "5m");
+        assert_eq!(meta.duration.actual_start, "2026-01-15T09:00:00Z");
+        assert_eq!(meta.duration.actual_end, "2026-01-15T09:05:00Z");
+        assert_eq!(meta.hosts.len(), 2);
+        assert_eq!(meta.hosts[0].name, "attacker-001");
+        assert_eq!(meta.hosts[0].ips, vec!["10.100.0.2"]);
+        assert_eq!(meta.hosts[1].name, "target-001");
+        assert_eq!(meta.hosts[1].ips, vec!["10.100.0.3"]);
+        assert_eq!(meta.network.segments.len(), 1);
+        assert_eq!(meta.network.segments[0].name, "lan");
+        assert_eq!(meta.capture.pcaps.len(), 1);
+        assert_eq!(meta.capture.pcaps[0].segment, "lan");
+        assert_eq!(meta.capture.pcaps[0].path, "net/capture-lan.pcap");
+    }
+
+    #[test]
+    fn build_meta_json_roundtrip() {
+        let (scenario, host_ips, start) = ac0_test_inputs();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["hosts"][0]["ips"][0], "10.100.0.2");
+        assert_eq!(value["hosts"][1]["ips"][0], "10.100.0.3");
+        assert_eq!(value["environment"]["scale"], "minimal");
+        assert_eq!(value["capture"]["pcaps"][0]["segment"], "lan");
+        assert_eq!(value["capture"]["pcaps"][0]["path"], "net/capture-lan.pcap");
+    }
+
+    #[test]
+    fn build_meta_matches_ac0_reference() {
+        let (scenario, host_ips, start) = ac0_test_inputs();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+        let actual: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&meta).unwrap()).unwrap();
+
+        let expected_str = include_str!("../scenarios/ac-0-expected/meta.json");
+        let expected: serde_json::Value = serde_json::from_str(expected_str).unwrap();
+
+        assert_eq!(actual, expected, "meta.json does not match reference");
+    }
+
+    #[test]
+    fn write_creates_valid_json_file() {
+        let (scenario, host_ips, start) = ac0_test_inputs();
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            start,
+        )
+        .unwrap();
+
+        let path = dir.path().join("meta.json");
+        assert!(path.exists(), "meta.json was not created");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(value["schema_version"], "1");
+        assert_eq!(value["hosts"][0]["name"], "attacker-001");
+    }
+
+    #[test]
+    fn build_meta_rejects_unknown_host() {
+        let (scenario, _, start) = ac0_test_inputs();
+        let host_ips = vec![("ghost-host".to_owned(), vec![Ipv4Addr::new(10, 100, 0, 99)])];
+
+        let err = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap_err();
+        assert!(
+            err.to_string().contains("not found in scenario"),
+            "unexpected error: {err}",
+        );
+    }
+}

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -2,10 +2,30 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result, ensure};
-use serde::Deserialize;
+use anyhow::{Context, Result, bail, ensure};
+use chrono::Duration;
+use ipnet::Ipv4Net;
+use serde::{Deserialize, Serialize};
 
 const SUPPORTED_VERSION: &str = "1";
+
+/// Parses a human-readable duration string like "5m", "30s", or "2h".
+pub(crate) fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_suffix('s') {
+        let secs: i64 = rest.parse().context("invalid seconds in duration")?;
+        return Duration::try_seconds(secs).context("duration seconds out of range");
+    }
+    if let Some(rest) = s.strip_suffix('m') {
+        let mins: i64 = rest.parse().context("invalid minutes in duration")?;
+        return Duration::try_minutes(mins).context("duration minutes out of range");
+    }
+    if let Some(rest) = s.strip_suffix('h') {
+        let hours: i64 = rest.parse().context("invalid hours in duration")?;
+        return Duration::try_hours(hours).context("duration hours out of range");
+    }
+    bail!("unsupported duration format '{s}': expected suffix s, m, or h")
+}
 
 /// Loads and validates a scenario from a YAML file.
 pub(crate) fn load(path: &Path) -> Result<Scenario> {
@@ -19,13 +39,10 @@ pub(crate) fn load(path: &Path) -> Result<Scenario> {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Scenario {
-    version: String,
+    pub(crate) version: String,
     pub(crate) metadata: Metadata,
-    // Pipeline will consume these once generation is implemented.
-    #[allow(dead_code)]
-    environment: Environment,
-    #[allow(dead_code)]
-    duration: String,
+    pub(crate) environment: Environment,
+    pub(crate) duration: String,
     pub(crate) infrastructure: Infrastructure,
     pub(crate) activities: Activities,
 }
@@ -33,20 +50,17 @@ pub(crate) struct Scenario {
 #[derive(Debug, Deserialize)]
 pub(crate) struct Metadata {
     pub(crate) name: String,
-    // Pipeline will consume this once generation is implemented.
     #[allow(dead_code)]
-    description: String,
+    pub(crate) description: String,
 }
 
-// Pipeline will consume these fields once generation is implemented.
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct Environment {
-    scale: Scale,
-    encryption: Encryption,
-    workload: Workload,
-    threat: Threat,
-    attacker: Attacker,
+    pub(crate) scale: Scale,
+    pub(crate) encryption: Encryption,
+    pub(crate) workload: Workload,
+    pub(crate) threat: Threat,
+    pub(crate) attacker: Attacker,
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,14 +69,12 @@ pub(crate) struct Infrastructure {
     pub(crate) network: Network,
 }
 
-// Pipeline will consume os, role, and image once generation is implemented.
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct Host {
-    name: String,
-    os: Os,
-    role: Role,
-    image: String,
+    pub(crate) name: String,
+    pub(crate) os: Os,
+    pub(crate) role: Role,
+    pub(crate) image: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -70,13 +82,11 @@ pub(crate) struct Network {
     pub(crate) segments: Vec<Segment>,
 }
 
-// Pipeline will consume subnet once generation is implemented.
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct Segment {
-    name: String,
-    subnet: String,
-    hosts: Vec<String>,
+    pub(crate) name: String,
+    pub(crate) subnet: String,
+    pub(crate) hosts: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -87,38 +97,34 @@ pub(crate) struct Activities {
     pub(crate) attack: Vec<AttackActivity>,
 }
 
-// Pipeline will consume command, protocol, dst_port, and start_offset
-// once generation is implemented.
-#[derive(Debug, Deserialize)]
 #[allow(dead_code)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct NormalActivity {
-    name: String,
-    source: String,
-    target: String,
-    command: String,
-    protocol: Protocol,
-    dst_port: u16,
-    start_offset: String,
+    pub(crate) name: String,
+    pub(crate) source: String,
+    pub(crate) target: String,
+    pub(crate) command: String,
+    pub(crate) protocol: Protocol,
+    pub(crate) dst_port: u16,
+    pub(crate) start_offset: String,
 }
 
-// Pipeline will consume command, protocol, dst_port, technique, phase,
-// tool, and start_offset once generation is implemented.
-#[derive(Debug, Deserialize)]
 #[allow(dead_code)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct AttackActivity {
-    name: String,
-    source: String,
-    target: String,
-    command: String,
-    protocol: Protocol,
-    dst_port: u16,
-    technique: String,
-    phase: Phase,
-    tool: String,
-    start_offset: String,
+    pub(crate) name: String,
+    pub(crate) source: String,
+    pub(crate) target: String,
+    pub(crate) command: String,
+    pub(crate) protocol: Protocol,
+    pub(crate) dst_port: u16,
+    pub(crate) technique: String,
+    pub(crate) phase: Phase,
+    pub(crate) tool: String,
+    pub(crate) start_offset: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Scale {
     Minimal,
@@ -127,14 +133,14 @@ pub(crate) enum Scale {
     Large,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Encryption {
     None,
     Tls,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Workload {
     Light,
@@ -142,28 +148,28 @@ pub(crate) enum Workload {
     Heavy,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Threat {
     Single,
     Multi,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Attacker {
     Scripted,
     Adaptive,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Os {
     Linux,
     Windows,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Role {
     Attacker,
@@ -171,7 +177,7 @@ pub(crate) enum Role {
     Observer,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Protocol {
     Tcp,
@@ -179,7 +185,7 @@ pub(crate) enum Protocol {
     Icmp,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Phase {
     Reconnaissance,
@@ -227,6 +233,9 @@ impl Scenario {
             self.version,
         );
 
+        parse_duration(&self.duration)
+            .with_context(|| format!("invalid duration '{}'", self.duration))?;
+
         ensure!(
             !self.infrastructure.hosts.is_empty(),
             "scenario must define at least one host",
@@ -257,6 +266,12 @@ impl Scenario {
                 segment_names.insert(segment.name.as_str()),
                 "duplicate segment name '{}'",
                 segment.name,
+            );
+            ensure!(
+                segment.subnet.parse::<Ipv4Net>().is_ok(),
+                "segment '{}' has invalid subnet CIDR '{}'",
+                segment.name,
+                segment.subnet,
             );
             for host_ref in &segment.hosts {
                 ensure!(
@@ -446,6 +461,43 @@ activities:
         assert_eq!(s.infrastructure.hosts.len(), 1);
         assert!(s.activities.normal.is_empty());
         assert!(s.activities.attack.is_empty());
+    }
+
+    // ── Duration validation ───────────────────────────────────────
+
+    #[test]
+    fn reject_invalid_duration_format() {
+        let yaml = MINIMAL_YAML.replace("duration: 1m", "duration: 5x");
+        let s: Scenario = serde_yaml::from_str(&yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("invalid duration"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn reject_non_numeric_duration() {
+        let yaml = MINIMAL_YAML.replace("duration: 1m", "duration: foom");
+        let s: Scenario = serde_yaml::from_str(&yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("invalid"),
+            "unexpected error: {err}",
+        );
+    }
+
+    // ── Subnet validation ────────────────────────────────────────
+
+    #[test]
+    fn reject_invalid_subnet_cidr() {
+        let yaml = MINIMAL_YAML.replace("subnet: 10.0.0.0/24", "subnet: not-a-cidr");
+        let s: Scenario = serde_yaml::from_str(&yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("invalid subnet CIDR"),
+            "unexpected error: {err}",
+        );
     }
 
     // ── Version validation ────────────────────────────────────────
@@ -1075,6 +1127,61 @@ activities:
             "unexpected error: {err}",
         );
     }
+
+    // ── Duration parsing ──────────────────────────────────────────
+
+    #[test]
+    fn parse_duration_seconds() {
+        let d = parse_duration("30s").unwrap();
+        assert_eq!(d.num_seconds(), 30);
+    }
+
+    #[test]
+    fn parse_duration_minutes() {
+        let d = parse_duration("5m").unwrap();
+        assert_eq!(d.num_seconds(), 300);
+    }
+
+    #[test]
+    fn parse_duration_hours() {
+        let d = parse_duration("2h").unwrap();
+        assert_eq!(d.num_seconds(), 7200);
+    }
+
+    #[test]
+    fn parse_duration_invalid_suffix() {
+        let err = parse_duration("10d").unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported duration format"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn parse_duration_invalid_number() {
+        let err = parse_duration("abcm").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn parse_duration_with_whitespace() {
+        let d = parse_duration("  5m  ").unwrap();
+        assert_eq!(d.num_seconds(), 300);
+    }
+
+    #[test]
+    fn parse_duration_empty_string() {
+        let err = parse_duration("").unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported duration format"),
+            "unexpected error: {err}",
+        );
+    }
+
+    // ── E2E: load() from file ─────────────────────────────────────
 
     #[test]
     fn load_valid_yaml_but_invalid_scenario() {


### PR DESCRIPTION
## Summary

- Add Docker provisioning via bollard: bridge networks with IPAM, static IP assignment from declared subnets, container creation, and tcpdump sidecar for PCAP capture
- Generate `meta.json` with host IPs, network segments, environment settings, and timing metadata
- Add fail-fast validation for duration format and subnet CIDR in `Scenario::validate()`
- 68 unit tests + 4 Docker E2E tests (`#[ignore]`)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes with zero warnings
- [x] `cargo test` passes (68 tests)
- [ ] Run `cargo test -- --ignored` with Docker daemon to verify E2E tests

Closes #12