### PR TITLE
Add parallel-safe Docker E2E subnets and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,20 @@ jobs:
 
       - name: Run Tests
         run: cargo test
+
+  docker-e2e:
+    name: Docker E2E
+    needs: [check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Docker E2E Tests
+        run: cargo test -- --ignored

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -565,12 +565,7 @@ mod tests {
 
     // ── Docker E2E tests ──────────────────────────────────────────
 
-    fn load_ac0() -> crate::scenario::Scenario {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("scenarios")
-            .join("ac-0.scenario.yaml");
-        crate::scenario::load(&path).unwrap()
-    }
+    use crate::test_util::{isolate_subnets, load_ac0, load_mixed_distro};
 
     /// Provisions ac-0 containers, runs both activities immediately
     /// (using a past start time to skip offset waits), and verifies
@@ -578,7 +573,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn exec_activities_in_ac0_containers() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();
@@ -604,6 +600,11 @@ mod tests {
 
         assert_eq!(results.len(), 2, "expected 1 normal + 1 attack execution");
 
+        let seg = &scenario.infrastructure.network.segments[0];
+        let (_, expected_ips) = crate::infra::assign_ips(&seg.subnet, &seg.hosts).unwrap();
+        let expected_src = expected_ips[0].1;
+        let expected_dst = expected_ips[1].1;
+
         // First result (normal — lower offset 30s).
         let normal = &results[0];
         assert!(normal.attack.is_none());
@@ -611,8 +612,8 @@ mod tests {
         assert_eq!(normal.target, "target-001");
         assert_eq!(normal.protocol, Protocol::Tcp);
         assert_eq!(normal.dst_port, 80);
-        assert_eq!(normal.src_ip, Ipv4Addr::new(10, 100, 0, 2));
-        assert_eq!(normal.dst_ip, Ipv4Addr::new(10, 100, 0, 3));
+        assert_eq!(normal.src_ip, expected_src);
+        assert_eq!(normal.dst_ip, expected_dst);
 
         // Timestamps must be actual wall-clock times, not estimated.
         assert!(
@@ -631,8 +632,8 @@ mod tests {
         assert_eq!(detail.technique, "T1046");
         assert_eq!(detail.phase, Phase::Reconnaissance);
         assert_eq!(detail.tool, "nmap");
-        assert_eq!(attack.src_ip, Ipv4Addr::new(10, 100, 0, 2));
-        assert_eq!(attack.dst_ip, Ipv4Addr::new(10, 100, 0, 3));
+        assert_eq!(attack.src_ip, expected_src);
+        assert_eq!(attack.dst_ip, expected_dst);
 
         assert!(
             attack.start >= before,
@@ -665,7 +666,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn activities_produce_valid_ground_truth() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         let gt_dir = dir.path().join("ground_truth");
@@ -691,6 +693,11 @@ mod tests {
         crate::pcap::enrich_src_ports(&net_dir, &mut results).unwrap();
         crate::ground_truth::write(dir.path(), &results).unwrap();
 
+        let seg = &scenario.infrastructure.network.segments[0];
+        let (_, expected_ips) = crate::infra::assign_ips(&seg.subnet, &seg.hosts).unwrap();
+        let attacker_ip = expected_ips[0].1.to_string();
+        let target_ip = expected_ips[1].1.to_string();
+
         let content = std::fs::read_to_string(gt_dir.join("manifest.jsonl")).unwrap();
         let lines: Vec<&str> = content.lines().collect();
         assert_eq!(lines.len(), 2);
@@ -701,9 +708,9 @@ mod tests {
         assert_eq!(r0["label"], "normal");
         assert_eq!(r0["session_type"], "network");
         assert_eq!(r0["protocol"], "tcp");
-        assert_eq!(r0["src_ip"], "10.100.0.2");
+        assert_eq!(r0["src_ip"], attacker_ip);
         assert!(r0["src_port"].is_number(), "src_port must be present");
-        assert_eq!(r0["dst_ip"], "10.100.0.3");
+        assert_eq!(r0["dst_ip"], target_ip);
         assert_eq!(r0["dst_port"], 80);
         assert!(r0.get("category").is_none());
         assert!(r0.get("technique").is_none());
@@ -724,12 +731,12 @@ mod tests {
         assert_eq!(r1["technique"], "T1046");
         assert_eq!(r1["phase"], "reconnaissance");
         assert_eq!(r1["tool"], "nmap");
-        assert_eq!(r1["src_ip"], "10.100.0.2");
+        assert_eq!(r1["src_ip"], attacker_ip);
         assert!(
             r1["src_port"].is_number(),
             "attack src_port must be present"
         );
-        assert_eq!(r1["dst_ip"], "10.100.0.3");
+        assert_eq!(r1["dst_ip"], target_ip);
 
         let attack_start_str = r1["start"].as_str().unwrap();
         let attack_start_ts = chrono::DateTime::parse_from_rfc3339(attack_start_str).unwrap();
@@ -743,13 +750,6 @@ mod tests {
 
     // ── Mixed-distro E2E tests ───────────────────────────────────
 
-    fn load_mixed_distro() -> crate::scenario::Scenario {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("scenarios")
-            .join("ac-1-mixed-distro.scenario.yaml");
-        crate::scenario::load(&path).unwrap()
-    }
-
     /// Alpine + Ubuntu hosts on the same segment complete without error.
     /// The attacker (Alpine) is the only activity source and must receive
     /// tools via `apk add`; the Ubuntu hosts (target + observer) must
@@ -757,7 +757,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn mixed_distro_installs_tools_only_in_source() {
-        let scenario = load_mixed_distro();
+        let mut scenario = load_mixed_distro();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();
@@ -807,6 +808,7 @@ mod tests {
     #[ignore = "requires Docker daemon"]
     async fn ubuntu_source_installs_tools_via_apt() {
         let mut scenario = load_mixed_distro();
+        isolate_subnets(&mut scenario);
 
         // Swap source/target so that apt-get is exercised on Ubuntu.
         scenario.activities.normal[0].source = "target-ubuntu".to_owned();
@@ -857,6 +859,7 @@ mod tests {
     #[ignore = "requires Docker daemon"]
     async fn dual_distro_sources_install_tools_concurrently() {
         let mut scenario = load_mixed_distro();
+        isolate_subnets(&mut scenario);
 
         // Make target-ubuntu also a source (in addition to attacker-alpine).
         scenario.activities.attack[0].source = "target-ubuntu".to_owned();
@@ -909,7 +912,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn pre_installed_tools_are_skipped() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -549,29 +549,28 @@ mod tests {
 
     // ── Docker E2E tests ──────────────────────────────────────────
 
-    fn load_ac0() -> crate::scenario::Scenario {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("scenarios")
-            .join("ac-0.scenario.yaml");
-        crate::scenario::load(&path).unwrap()
-    }
+    use crate::test_util::{isolate_subnets, load_ac0};
 
     /// Provisions and tears down ac-0 infrastructure — requires Docker.
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn provision_ac0_assigns_correct_ips() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();
 
         let env = ProvisionedEnv::up(&scenario, &net_dir).await.unwrap();
 
+        let seg = &scenario.infrastructure.network.segments[0];
+        let (_, expected_ips) = assign_ips(&seg.subnet, &seg.hosts).unwrap();
+
         assert_eq!(env.host_ips.len(), 2);
         assert_eq!(env.host_ips[0].0, "attacker-001");
-        assert_eq!(env.host_ips[0].1, vec![Ipv4Addr::new(10, 100, 0, 2)]);
+        assert_eq!(env.host_ips[0].1, vec![expected_ips[0].1]);
         assert_eq!(env.host_ips[1].0, "target-001");
-        assert_eq!(env.host_ips[1].1, vec![Ipv4Addr::new(10, 100, 0, 3)]);
+        assert_eq!(env.host_ips[1].1, vec![expected_ips[1].1]);
 
         // host_containers must map each host to a valid container ID.
         assert_eq!(env.host_containers.len(), 2);
@@ -610,7 +609,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn provisioned_containers_have_connectivity() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();
@@ -657,7 +657,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn stop_collectors_stops_capture_containers() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();
@@ -716,7 +717,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn teardown_removes_containers_and_networks() {
-        let scenario = load_ac0();
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
         let dir = tempfile::tempdir().unwrap();
         let net_dir = dir.path().join("net");
         std::fs::create_dir_all(&net_dir).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ mod infra;
 mod meta;
 mod pcap;
 mod scenario;
+#[cfg(test)]
+mod test_util;
 
 #[derive(Parser)]
 #[command(
@@ -184,13 +186,7 @@ fn validate(bundle: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn load_ac0() -> scenario::Scenario {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("scenarios")
-            .join("ac-0.scenario.yaml");
-        scenario::load(&path).unwrap()
-    }
+    use crate::test_util::load_ac0;
 
     // ── assemble_bundle ────────────────────────────────────────
 
@@ -451,30 +447,48 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires Docker daemon"]
     async fn generate_ac0_produces_valid_bundle() {
-        let scenario_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("scenarios")
-            .join("ac-0.scenario.yaml");
-        let dir = tempfile::tempdir().unwrap();
-        let output = dir.path().to_str().unwrap();
+        // Create a temp copy of the scenario with a unique subnet.
+        let subnet = test_util::unique_subnet();
+        let original = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("scenarios")
+                .join("ac-0.scenario.yaml"),
+        )
+        .unwrap();
+        let modified = original.replace("10.100.0.0/24", &subnet);
 
-        generate(scenario_path.to_str().unwrap(), output)
-            .await
-            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let scenario_path = dir.path().join("ac-0.scenario.yaml");
+        fs::write(&scenario_path, &modified).unwrap();
+
+        let output_dir = dir.path().join("output");
+        generate(
+            scenario_path.to_str().unwrap(),
+            output_dir.to_str().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Derive expected IPs from the assigned subnet.
+        let hosts = vec!["attacker-001".to_owned(), "target-001".to_owned()];
+        let (_, expected_ips) = infra::assign_ips(&subnet, &hosts).unwrap();
+        let attacker_ip = expected_ips[0].1.to_string();
+        let target_ip = expected_ips[1].1.to_string();
 
         // ── Bundle directory structure ────────────────────────────
-        assert!(dir.path().join("net").is_dir());
-        assert!(dir.path().join("ground_truth").is_dir());
-        assert!(dir.path().join("host/attacker-001").is_dir());
-        assert!(dir.path().join("host/target-001").is_dir());
+        assert!(output_dir.join("net").is_dir());
+        assert!(output_dir.join("ground_truth").is_dir());
+        assert!(output_dir.join("host/attacker-001").is_dir());
+        assert!(output_dir.join("host/target-001").is_dir());
 
         // ── PCAP present and non-empty ───────────────────────────
-        let pcap_path = dir.path().join("net/capture-lan.pcap");
+        let pcap_path = output_dir.join("net/capture-lan.pcap");
         assert!(pcap_path.exists(), "pcap file was not created");
         let pcap_len = fs::metadata(&pcap_path).unwrap().len();
         assert!(pcap_len > 24, "pcap must be larger than the global header");
 
         // ── meta.json ────────────────────────────────────────────
-        let meta_path = dir.path().join("meta.json");
+        let meta_path = output_dir.join("meta.json");
         assert!(meta_path.exists(), "meta.json was not created");
         let meta_content = fs::read_to_string(&meta_path).unwrap();
         let meta: serde_json::Value = serde_json::from_str(&meta_content).unwrap();
@@ -482,16 +496,16 @@ mod tests {
         assert_eq!(meta["scenario"], "ac-0.scenario.yaml");
         assert_eq!(meta["duration"]["total"], "5m");
         assert_eq!(meta["hosts"][0]["name"], "attacker-001");
-        assert_eq!(meta["hosts"][0]["ips"][0], "10.100.0.2");
+        assert_eq!(meta["hosts"][0]["ips"][0], attacker_ip);
         assert_eq!(meta["hosts"][1]["name"], "target-001");
-        assert_eq!(meta["hosts"][1]["ips"][0], "10.100.0.3");
+        assert_eq!(meta["hosts"][1]["ips"][0], target_ip);
         assert_eq!(meta["network"]["segments"][0]["name"], "lan");
-        assert_eq!(meta["network"]["segments"][0]["subnet"], "10.100.0.0/24");
+        assert_eq!(meta["network"]["segments"][0]["subnet"], subnet);
         assert_eq!(meta["capture"]["pcaps"][0]["segment"], "lan");
         assert_eq!(meta["capture"]["pcaps"][0]["path"], "net/capture-lan.pcap",);
 
         // ── ground_truth/manifest.jsonl ──────────────────────────
-        let gt_path = dir.path().join("ground_truth/manifest.jsonl");
+        let gt_path = output_dir.join("ground_truth/manifest.jsonl");
         assert!(gt_path.exists(), "manifest.jsonl was not created");
         let gt_content = fs::read_to_string(&gt_path).unwrap();
         let lines: Vec<&str> = gt_content.lines().collect();
@@ -505,12 +519,12 @@ mod tests {
         assert_eq!(r0["target"], "target-001");
         assert_eq!(r0["session_type"], "network");
         assert_eq!(r0["protocol"], "tcp");
-        assert_eq!(r0["src_ip"], "10.100.0.2");
+        assert_eq!(r0["src_ip"], attacker_ip);
         assert!(
             r0["src_port"].as_u64().unwrap() > 0,
             "src_port must be enriched"
         );
-        assert_eq!(r0["dst_ip"], "10.100.0.3");
+        assert_eq!(r0["dst_ip"], target_ip);
         assert_eq!(r0["dst_port"], 80);
         assert!(
             r0.get("category").is_none(),
@@ -525,12 +539,12 @@ mod tests {
         assert_eq!(r1["target"], "target-001");
         assert_eq!(r1["session_type"], "network");
         assert_eq!(r1["protocol"], "tcp");
-        assert_eq!(r1["src_ip"], "10.100.0.2");
+        assert_eq!(r1["src_ip"], attacker_ip);
         assert!(
             r1["src_port"].as_u64().unwrap() > 0,
             "src_port must be enriched"
         );
-        assert_eq!(r1["dst_ip"], "10.100.0.3");
+        assert_eq!(r1["dst_ip"], target_ip);
         assert_eq!(r1["dst_port"], 80);
         assert_eq!(r1["category"], "attack");
         assert_eq!(r1["technique"], "T1046");

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Monotonically increasing counter for assigning each Docker E2E test
+/// a unique `/24` subnet, avoiding network collisions under parallel
+/// execution.  Starts at 1 to skip `10.0.0.0/24`.
+static SUBNET_COUNTER: AtomicU8 = AtomicU8::new(1);
+
+/// Returns a unique subnet like `"10.1.0.0/24"`, `"10.2.0.0/24"`, etc.
+pub(crate) fn unique_subnet() -> String {
+    let n = SUBNET_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("10.{n}.0.0/24")
+}
+
+/// Replaces every segment subnet in the scenario with a unique one so
+/// that parallel Docker E2E tests do not collide.
+pub(crate) fn isolate_subnets(scenario: &mut crate::scenario::Scenario) {
+    for seg in &mut scenario.infrastructure.network.segments {
+        seg.subnet = unique_subnet();
+    }
+}
+
+/// Loads the `ac-0.scenario.yaml` acceptance scenario.
+pub(crate) fn load_ac0() -> crate::scenario::Scenario {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("ac-0.scenario.yaml");
+    crate::scenario::load(&path).unwrap()
+}
+
+/// Loads the `ac-1-mixed-distro.scenario.yaml` acceptance scenario.
+pub(crate) fn load_mixed_distro() -> crate::scenario::Scenario {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scenarios")
+        .join("ac-1-mixed-distro.scenario.yaml");
+    crate::scenario::load(&path).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_subnet_returns_valid_cidr() {
+        let subnet = unique_subnet();
+        assert!(
+            subnet.parse::<ipnet::Ipv4Net>().is_ok(),
+            "not a valid CIDR: {subnet}",
+        );
+    }
+
+    #[test]
+    fn unique_subnet_returns_distinct_values() {
+        let a = unique_subnet();
+        let b = unique_subnet();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn isolate_subnets_replaces_all_segments() {
+        let mut scenario = load_ac0();
+        let original = scenario.infrastructure.network.segments[0].subnet.clone();
+
+        isolate_subnets(&mut scenario);
+
+        let replaced = &scenario.infrastructure.network.segments[0].subnet;
+        assert_ne!(replaced, &original);
+        assert!(
+            replaced.parse::<ipnet::Ipv4Net>().is_ok(),
+            "replaced subnet is not valid CIDR: {replaced}",
+        );
+    }
+
+    #[test]
+    fn isolate_subnets_gives_distinct_per_call() {
+        let mut s1 = load_ac0();
+        let mut s2 = load_ac0();
+        isolate_subnets(&mut s1);
+        isolate_subnets(&mut s2);
+
+        assert_ne!(
+            s1.infrastructure.network.segments[0].subnet,
+            s2.infrastructure.network.segments[0].subnet,
+        );
+    }
+
+    #[test]
+    fn isolate_subnets_assigns_distinct_per_segment() {
+        let yaml = "\
+version: '1'
+metadata:
+  name: multi-seg
+  description: test
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+duration: 1m
+infrastructure:
+  hosts:
+    - name: h1
+      os: linux
+      role: attacker
+      image: alpine:3.19
+    - name: h2
+      os: linux
+      role: target
+      image: alpine:3.19
+  network:
+    segments:
+      - name: dmz
+        subnet: 10.0.0.0/24
+        hosts:
+          - h1
+      - name: internal
+        subnet: 10.1.0.0/24
+        hosts:
+          - h2
+activities:
+  normal: []
+  attack: []
+";
+        let mut scenario: crate::scenario::Scenario = serde_yaml::from_str(yaml).unwrap();
+        isolate_subnets(&mut scenario);
+
+        let subnets: Vec<&str> = scenario
+            .infrastructure
+            .network
+            .segments
+            .iter()
+            .map(|s| s.subnet.as_str())
+            .collect();
+        assert_ne!(
+            subnets[0], subnets[1],
+            "each segment must get a distinct subnet"
+        );
+        for subnet in &subnets {
+            assert!(
+                subnet.parse::<ipnet::Ipv4Net>().is_ok(),
+                "not a valid CIDR: {subnet}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `test_util` module with atomic subnet allocator (`unique_subnet()`, `isolate_subnets()`) so all 11 Docker E2E tests get unique `/24` subnets and can run in parallel without Docker network collisions
- Replace ~20 hardcoded IP assertions (`10.100.0.2`, `10.100.0.3`, etc.) with values derived dynamically from the assigned subnet via `assign_ips()`
- Add `docker-e2e` CI job that runs `cargo test -- --ignored` on ubuntu-latest (Docker pre-installed)
- Deduplicate `load_ac0()` (3 copies) and `load_mixed_distro()` into `test_util`
- Add 5 unit tests for the new helpers (valid CIDR, distinct values, single/multi-segment isolation)

## Test plan
- [x] `cargo test` passes (135 passed, 0 failed, 11 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` clean
- [x] `cargo test -- --ignored` passes on a Docker-enabled host (11 passed, 123s)

Closes #41