### PR TITLE
Add AC-0 pipeline CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,29 @@ jobs:
       - name: Run Tests
         run: cargo test
 
+  ac0-pipeline:
+    name: AC-0 Pipeline
+    needs: [check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Generate AC-0 bundle
+        run: cargo run --release -- generate -s scenarios/ac-0.scenario.yaml -o ac0-bundle
+
+      - name: Validate AC-0 bundle
+        run: cargo run --release -- validate -b ac0-bundle
+
   docker-e2e:
     name: Docker E2E
     needs: [check]

--- a/scenarios/ac-0.scenario.yaml
+++ b/scenarios/ac-0.scenario.yaml
@@ -26,6 +26,8 @@ infrastructure:
       os: linux
       role: target
       image: alpine:3.19
+      setup:
+        - "while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 3\\r\\n\\r\\nok\\n' | nc -l -p 80 > /dev/null; done &"
   network:
     segments:
       - name: lan

--- a/scenarios/ac-1-mixed-distro.scenario.yaml
+++ b/scenarios/ac-1-mixed-distro.scenario.yaml
@@ -27,6 +27,8 @@ infrastructure:
       os: linux
       role: target
       image: ubuntu:22.04
+      setup:
+        - "apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq netcat-openbsd >/dev/null 2>&1 && { while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 3\\r\\n\\r\\nok\\n' | nc -l -p 80 -q 0 > /dev/null; done & }"
     - name: observer-ubuntu
       os: linux
       role: observer

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use tokio::task::JoinSet;
 
-use crate::scenario::{Activities, Phase, Protocol, parse_duration};
+use crate::scenario::{Activities, Host, Phase, Protocol, parse_duration};
 
 /// Seconds to wait after the last activity so trailing packets reach
 /// the tcpdump capture containers.
@@ -26,6 +26,8 @@ pub(crate) struct Execution {
     pub(crate) dst_ip: Ipv4Addr,
     pub(crate) dst_port: u16,
     pub(crate) attack: Option<AttackDetail>,
+    pub(crate) exit_code: i64,
+    pub(crate) command: String,
 }
 
 pub(crate) struct AttackDetail {
@@ -49,6 +51,36 @@ struct AttackRef<'a> {
     technique: &'a str,
     phase: Phase,
     tool: &'a str,
+}
+
+/// Runs per-host setup commands before any activities start.
+///
+/// Each command runs sequentially inside the host's container and must
+/// exit with code 0.  Typical use: start a background service (e.g.
+/// `busybox httpd`) that activities will target.
+pub(crate) async fn run_setup(
+    docker: &Docker,
+    hosts: &[Host],
+    host_containers: &[(String, String)],
+) -> Result<()> {
+    for host in hosts {
+        if host.setup.is_empty() {
+            continue;
+        }
+        let container_id = lookup_container(host_containers, &host.name)?;
+        for cmd in &host.setup {
+            println!("  Setup {}: {cmd}", host.name);
+            let code = exec_in_container(docker, container_id, cmd)
+                .await
+                .with_context(|| format!("setup command failed in '{}'", host.name))?;
+            anyhow::ensure!(
+                code == 0,
+                "setup command failed in '{}' (exit code {code}): {cmd}",
+                host.name,
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Executes all activities concurrently and returns execution results.
@@ -112,13 +144,13 @@ pub(crate) async fn run(
 
             println!("  Executing: {command}");
             let start = Utc::now();
-            let code = exec_in_container(&docker, &container_id, &command)
+            let exit_code = exec_in_container(&docker, &container_id, &command)
                 .await
                 .with_context(|| format!("activity exec failed in '{source}'"))?;
             let end = Utc::now();
 
-            if code != 0 {
-                eprintln!("  Warning: command exited with code {code}: {command}");
+            if exit_code != 0 {
+                eprintln!("  Warning: command exited with code {exit_code}: {command}");
             }
 
             Ok::<Execution, anyhow::Error>(Execution {
@@ -132,6 +164,8 @@ pub(crate) async fn run(
                 dst_ip,
                 dst_port,
                 attack,
+                exit_code,
+                command,
             })
         });
     }

--- a/src/ground_truth.rs
+++ b/src/ground_truth.rs
@@ -110,6 +110,8 @@ mod tests {
             dst_ip: Ipv4Addr::new(10, 100, 0, 3),
             dst_port: 80,
             attack: None,
+            exit_code: 0,
+            command: String::new(),
         }
     }
 
@@ -129,6 +131,8 @@ mod tests {
                 phase: Phase::Reconnaissance,
                 tool: "nmap".to_owned(),
             }),
+            exit_code: 0,
+            command: String::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,8 @@ async fn generate(scenario_path: &str, output: &str) -> Result<()> {
         scenario.infrastructure.network.segments.len(),
     );
 
-    // Run activities, then assemble the bundle; always tear down afterward.
-    println!("Running activities…");
-    let result = run_and_assemble(&env, &scenario, scenario_path, output_dir, start).await;
+    // Run setup, activities, then assemble the bundle; always tear down.
+    let result = setup_run_and_assemble(&env, &scenario, scenario_path, output_dir, start).await;
 
     let teardown_result = env.down().await;
     result?;
@@ -104,14 +103,23 @@ async fn generate(scenario_path: &str, output: &str) -> Result<()> {
     Ok(())
 }
 
-/// Executes activities, stops collectors, and assembles the output bundle.
-async fn run_and_assemble(
+/// Runs setup commands, executes activities, stops collectors, and
+/// assembles the output bundle.
+async fn setup_run_and_assemble(
     env: &infra::ProvisionedEnv,
     scenario: &scenario::Scenario,
     scenario_path: &str,
     output_dir: &Path,
     start: chrono::DateTime<chrono::Utc>,
 ) -> Result<()> {
+    activity::run_setup(
+        &env.docker,
+        &scenario.infrastructure.hosts,
+        &env.host_containers,
+    )
+    .await?;
+
+    println!("Running activities…");
     let mut executions = activity::run(
         &env.docker,
         &env.host_containers,
@@ -121,6 +129,19 @@ async fn run_and_assemble(
     )
     .await?;
     println!("Executed {} activity(ies)", executions.len());
+
+    // Fail early if any activity command returned a non-zero exit code.
+    let failures: Vec<_> = executions
+        .iter()
+        .filter(|e| e.exit_code != 0)
+        .map(|e| format!("exit code {}: {}", e.exit_code, e.command))
+        .collect();
+    anyhow::ensure!(
+        failures.is_empty(),
+        "{} activity command(s) failed:\n  {}",
+        failures.len(),
+        failures.join("\n  "),
+    );
 
     // Stop capture containers so pcap files are flushed and complete.
     env.stop_collectors().await?;
@@ -260,6 +281,8 @@ mod tests {
             dst_ip: std::net::Ipv4Addr::new(10, 100, 0, 3),
             dst_port: 80,
             attack,
+            exit_code: 0,
+            command: String::new(),
         }
     }
 

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -417,6 +417,8 @@ mod tests {
             dst_port,
             src_port: 0,
             attack: None,
+            exit_code: 0,
+            command: String::new(),
         }
     }
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -75,6 +75,8 @@ pub(crate) struct Host {
     pub(crate) os: Os,
     pub(crate) role: Role,
     pub(crate) image: String,
+    #[serde(default)]
+    pub(crate) setup: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -398,12 +400,15 @@ activities:
         assert_eq!(attacker.os, Os::Linux);
         assert_eq!(attacker.role, Role::Attacker);
         assert_eq!(attacker.image, "alpine:3.19");
+        assert!(attacker.setup.is_empty());
 
         let target = &s.infrastructure.hosts[1];
         assert_eq!(target.name, "target-001");
         assert_eq!(target.os, Os::Linux);
         assert_eq!(target.role, Role::Target);
         assert_eq!(target.image, "alpine:3.19");
+        assert_eq!(target.setup.len(), 1);
+        assert!(target.setup[0].contains("nc -l"));
     }
 
     #[test]
@@ -459,6 +464,12 @@ activities:
         assert_eq!(s.infrastructure.hosts.len(), 1);
         assert!(s.activities.normal.is_empty());
         assert!(s.activities.attack.is_empty());
+    }
+
+    #[test]
+    fn setup_defaults_to_empty_when_omitted() {
+        let s: Scenario = serde_yaml::from_str(MINIMAL_YAML).unwrap();
+        assert!(s.infrastructure.hosts[0].setup.is_empty());
     }
 
     // ── Duration validation ───────────────────────────────────────

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -611,17 +611,31 @@ fn validate_l4_lite(bundle: &Path, records: &[Value], checks: &mut Vec<Check>) {
         return;
     }
 
-    for record in &network_records {
-        if matches_any_packet(record, &packets) {
-            checks.push(pass(
-                "L4-001",
-                "at least one GT network session matches a PCAP flow",
-            ));
-            return;
+    let mut unmatched = Vec::new();
+    for (i, record) in network_records.iter().enumerate() {
+        if !matches_any_packet(record, &packets) {
+            unmatched.push(i + 1);
         }
     }
 
-    checks.push(fail("L4-001", "no GT session matches any PCAP flow"));
+    if unmatched.is_empty() {
+        checks.push(pass(
+            "L4-001",
+            format!(
+                "all {} GT network session(s) match a PCAP flow",
+                network_records.len(),
+            ),
+        ));
+    } else {
+        checks.push(fail(
+            "L4-001",
+            format!(
+                "{}/{} GT network session(s) have no matching PCAP flow: records {unmatched:?}",
+                unmatched.len(),
+                network_records.len(),
+            ),
+        ));
+    }
 }
 
 fn matches_any_packet(record: &Value, packets: &[pcap::Packet]) -> bool {
@@ -1105,6 +1119,24 @@ mod tests {
     }
 
     // ── L4 failures ─────────────────────────────────────────
+
+    #[test]
+    fn partial_pcap_match_fails_l4_001() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+        // PCAP matches only the normal record (port 80 at 09:00:30Z),
+        // but not the attack record (port 80 at 09:02:00Z).
+        let data = build_pcap(&[PcapFlow {
+            ts: ts_for("2026-01-15T09:00:30Z"),
+            src_ip: [10, 100, 0, 2],
+            dst_ip: [10, 100, 0, 3],
+            src_port: 49152,
+            dst_port: 80,
+        }]);
+        fs::write(dir.path().join("net/capture-lan.pcap"), data).unwrap();
+        let report = run(dir.path()).unwrap();
+        assert_fail(&report, "L4-001");
+    }
 
     #[test]
     fn no_matching_pcap_flow_fails_l4_001() {


### PR DESCRIPTION
## Summary

- Add `ac0-pipeline` CI job that builds the release binary, generates an AC-0 bundle, and validates it
- Every push now triggers end-to-end AC-0 generation and validation via the actual CLI
- Build fails automatically if the Validator reports errors (exit code 2)
- Strengthen L4-001 to validate ALL GT network records match PCAP flows (not just one)
- Propagate activity command failures: `generate` now fails when any activity exits non-zero
- Add per-host `setup` field to scenarios so target containers serve HTTP before activities run

## Test plan

- [x] Verify `ac0-pipeline` job appears in GitHub Actions and runs on push
- [x] Verify existing `docker-e2e` and `test` jobs still pass

Closes #24