### PR TITLE
Add Windows VM provisioning and Sysmon collection (#19)

### DIFF
--- a/scenarios/ac-2-windows.scenario.yaml
+++ b/scenarios/ac-2-windows.scenario.yaml
@@ -1,0 +1,65 @@
+version: "1"
+
+metadata:
+  name: ac-2-windows
+  description: >-
+    Minimal Windows VM scenario. One Linux container (attacker) and
+    one Windows VM (target) on one network segment. Exercises VM
+    provisioning via libvirt, Sysmon telemetry collection, and a
+    simple nmap port scan against Windows services.
+
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+
+duration: 10m
+
+infrastructure:
+  hosts:
+    - name: attacker-001
+      os: linux
+      role: attacker
+      image: alpine:3.19
+    - name: win-target-001
+      os: windows
+      role: target
+      vm:
+        base_image: /var/lib/libvirt/images/windows-server-2022.qcow2
+        memory_mb: 4096
+        vcpus: 2
+        ssh_user: admin
+        ssh_password: changeme
+        sysmon: true
+      setup:
+        - "powershell -Command \"New-NetFirewallRule -DisplayName 'Allow ICMP' -Protocol ICMPv4 -Action Allow\""
+  network:
+    segments:
+      - name: lan
+        subnet: 10.100.0.0/24
+        hosts:
+          - attacker-001
+          - win-target-001
+
+activities:
+  normal:
+    - name: smb-probe
+      source: attacker-001
+      target: win-target-001
+      command: "curl -s --connect-timeout 5 http://${target_ip}:445/ || true"
+      protocol: tcp
+      dst_port: 445
+      start_offset: 60s
+  attack:
+    - name: nmap-windows-scan
+      source: attacker-001
+      target: win-target-001
+      command: "nmap -sS -p 135,139,445,3389 ${target_ip}"
+      protocol: tcp
+      dst_port: 445
+      technique: T1046
+      phase: reconnaissance
+      tool: nmap
+      start_offset: 300s

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -9,6 +9,7 @@ use futures_util::StreamExt;
 use tokio::task::JoinSet;
 
 use crate::scenario::{Activities, Host, Phase, Protocol, parse_duration};
+use crate::vm::{self, ProvisionedVm};
 
 /// Seconds to wait after the last activity so trailing packets reach
 /// the tcpdump capture containers.
@@ -55,49 +56,88 @@ struct AttackRef<'a> {
 
 /// Runs per-host setup commands before any activities start.
 ///
-/// Each command runs sequentially inside the host's container and must
-/// exit with code 0.  Typical use: start a background service (e.g.
-/// `busybox httpd`) that activities will target.
+/// Each command runs sequentially inside the host's container (or via
+/// SSH for VM hosts) and must exit with code 0.  Typical use: start a
+/// background service (e.g. `busybox httpd`) that activities will
+/// target.
 pub(crate) async fn run_setup(
     docker: &Docker,
     hosts: &[Host],
     host_containers: &[(String, String)],
+    vms: &[ProvisionedVm],
 ) -> Result<()> {
     for host in hosts {
         if host.setup.is_empty() {
             continue;
         }
-        let container_id = lookup_container(host_containers, &host.name)?;
-        for cmd in &host.setup {
-            println!("  Setup {}: {cmd}", host.name);
-            let code = exec_in_container(docker, container_id, cmd)
+
+        if host.is_vm() {
+            let vm_host = lookup_vm(vms, &host.name)?;
+            for cmd in &host.setup {
+                println!("  Setup {} (VM): {cmd}", host.name);
+                let code = vm::exec_ssh(
+                    &vm_host.mgmt_ip,
+                    &vm_host.ssh_user,
+                    &vm_host.ssh_password,
+                    cmd,
+                )
                 .await
-                .with_context(|| format!("setup command failed in '{}'", host.name))?;
-            anyhow::ensure!(
-                code == 0,
-                "setup command failed in '{}' (exit code {code}): {cmd}",
-                host.name,
-            );
+                .with_context(|| format!("setup command failed in VM '{}'", host.name))?;
+                anyhow::ensure!(
+                    code == 0,
+                    "setup command failed in VM '{}' (exit code {code}): {cmd}",
+                    host.name,
+                );
+            }
+        } else {
+            let container_id = lookup_container(host_containers, &host.name)?;
+            for cmd in &host.setup {
+                println!("  Setup {}: {cmd}", host.name);
+                let code = exec_in_container(docker, container_id, cmd)
+                    .await
+                    .with_context(|| format!("setup command failed in '{}'", host.name))?;
+                anyhow::ensure!(
+                    code == 0,
+                    "setup command failed in '{}' (exit code {code}): {cmd}",
+                    host.name,
+                );
+            }
         }
     }
     Ok(())
+}
+
+/// Backend for executing a command during an activity.
+enum ExecBackend {
+    /// Docker container identified by container ID.
+    Docker {
+        docker: Docker,
+        container_id: String,
+    },
+    /// Libvirt VM reached via SSH.
+    Ssh {
+        mgmt_ip: Ipv4Addr,
+        ssh_user: String,
+        ssh_password: String,
+    },
 }
 
 /// Executes all activities concurrently and returns execution results.
 ///
 /// Each activity is spawned as an independent task that sleeps until its
 /// `start_offset` elapses, then executes the command inside the source
-/// host's container via Docker exec.  This ensures activities with the
-/// same offset (or whose offset has already passed) start without waiting
-/// for earlier commands to finish.  Tool packages (curl, nmap) are
-/// installed before any activity runs.
+/// host's container via Docker exec (or via SSH for VM hosts).  Tool
+/// packages (curl, nmap) are installed in container-based sources
+/// before any activity runs.
 pub(crate) async fn run(
     docker: &Docker,
     host_containers: &[(String, String)],
     host_ips: &[(String, Vec<Ipv4Addr>)],
     activities: &Activities,
     generation_start: DateTime<Utc>,
+    vms: &[ProvisionedVm],
 ) -> Result<Vec<Execution>> {
+    // Install tools only in Docker-based activity sources.
     let sources = activity_sources(activities);
     let source_containers: Vec<_> = host_containers
         .iter()
@@ -109,25 +149,21 @@ pub(crate) async fn run(
     let mut schedule = build_schedule(activities)?;
     schedule.sort_unstable_by_key(|s| s.offset);
 
-    // Resolve IPs and container IDs upfront so errors surface early.
+    // Resolve IPs and execution backend upfront so errors surface early.
     let prepared: Vec<_> = schedule
         .iter()
         .map(|a| {
             let src_ip = lookup_ip(host_ips, a.source)?;
             let dst_ip = lookup_ip(host_ips, a.target)?;
             let command = a.command.replace("${target_ip}", &dst_ip.to_string());
-            let container_id = lookup_container(host_containers, a.source)?;
-            Ok((a, src_ip, dst_ip, command, container_id.to_owned()))
+            let backend = resolve_backend(docker, host_containers, vms, a.source)?;
+            Ok((a, src_ip, dst_ip, command, backend))
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // Spawn each activity as an independent task. Each task sleeps
-    // until its scheduled offset, then executes the command.  This
-    // ensures activities whose offsets have already elapsed (or share
-    // the same offset) start without waiting for earlier execs.
+    // Spawn each activity as an independent task.
     let mut tasks = JoinSet::new();
-    for (activity, src_ip, dst_ip, command, container_id) in prepared {
-        let docker = docker.clone();
+    for (activity, src_ip, dst_ip, command, backend) in prepared {
         let target_time = generation_start + activity.offset;
         let source = activity.source.to_owned();
         let target = activity.target.to_owned();
@@ -144,9 +180,21 @@ pub(crate) async fn run(
 
             println!("  Executing: {command}");
             let start = Utc::now();
-            let exit_code = exec_in_container(&docker, &container_id, &command)
-                .await
-                .with_context(|| format!("activity exec failed in '{source}'"))?;
+            let exit_code = match &backend {
+                ExecBackend::Docker {
+                    docker,
+                    container_id,
+                } => exec_in_container(docker, container_id, &command)
+                    .await
+                    .with_context(|| format!("activity exec failed in '{source}'"))?,
+                ExecBackend::Ssh {
+                    mgmt_ip,
+                    ssh_user,
+                    ssh_password,
+                } => vm::exec_ssh(mgmt_ip, ssh_user, ssh_password, &command)
+                    .await
+                    .with_context(|| format!("activity SSH exec failed in '{source}'"))?,
+            };
             let end = Utc::now();
 
             if exit_code != 0 {
@@ -180,6 +228,29 @@ pub(crate) async fn run(
     tokio::time::sleep(std::time::Duration::from_secs(CAPTURE_DRAIN_SECS)).await;
 
     Ok(results)
+}
+
+/// Resolves the execution backend for a given source host.
+fn resolve_backend(
+    docker: &Docker,
+    host_containers: &[(String, String)],
+    vms: &[ProvisionedVm],
+    source: &str,
+) -> Result<ExecBackend> {
+    // Check VMs first.
+    if let Some(vm_host) = vms.iter().find(|v| v.host_name == source) {
+        return Ok(ExecBackend::Ssh {
+            mgmt_ip: vm_host.mgmt_ip,
+            ssh_user: vm_host.ssh_user.clone(),
+            ssh_password: vm_host.ssh_password.clone(),
+        });
+    }
+    // Fall back to Docker container.
+    let container_id = lookup_container(host_containers, source)?;
+    Ok(ExecBackend::Docker {
+        docker: docker.clone(),
+        container_id: container_id.to_owned(),
+    })
 }
 
 fn build_schedule(activities: &Activities) -> Result<Vec<Scheduled<'_>>> {
@@ -241,6 +312,12 @@ fn lookup_container<'a>(host_containers: &'a [(String, String)], host: &str) -> 
         .find(|(name, _)| name == host)
         .map(|(_, id)| id.as_str())
         .with_context(|| format!("no container found for host '{host}'"))
+}
+
+fn lookup_vm<'a>(vms: &'a [ProvisionedVm], host: &str) -> Result<&'a ProvisionedVm> {
+    vms.iter()
+        .find(|v| v.host_name == host)
+        .with_context(|| format!("no VM found for host '{host}'"))
 }
 
 /// Returns the set of host names that appear as activity sources.
@@ -653,6 +730,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -746,6 +824,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -840,6 +919,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -899,6 +979,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -948,6 +1029,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -1051,6 +1133,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -1098,6 +1181,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             past_start,
+            &[],
         )
         .await
         .unwrap();
@@ -1183,6 +1267,7 @@ mod tests {
             &env.host_ips,
             &scenario.activities,
             start,
+            &[],
         )
         .await
         .unwrap();

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher;
 use std::net::Ipv4Addr;
 use std::path::Path;
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use bollard::Docker;
 use bollard::container::{
     Config, CreateContainerOptions, NetworkingConfig, RemoveContainerOptions,
@@ -15,11 +15,12 @@ use futures_util::TryStreamExt;
 use ipnet::Ipv4Net;
 
 use crate::scenario::Scenario;
+use crate::vm;
 
 const CAPTURE_IMAGE: &str = "alpine:3.19";
 const LINUX_IFNAMSIZ: usize = 15;
 
-/// Holds provisioned Docker resources and assigned host IPs.
+/// Holds provisioned Docker resources, VMs, and assigned host IPs.
 ///
 /// Each entry in `host_ips` maps a host name to **all** IPs assigned
 /// across every segment the host belongs to (primary first).
@@ -30,6 +31,8 @@ pub(crate) struct ProvisionedEnv {
     capture_container_ids: Vec<String>,
     pub(crate) host_ips: Vec<(String, Vec<Ipv4Addr>)>,
     pub(crate) host_containers: Vec<(String, String)>,
+    /// Provisioned libvirt VMs (Windows hosts).
+    pub(crate) vms: Vec<vm::ProvisionedVm>,
 }
 
 /// Per-segment state accumulated during provisioning.
@@ -116,6 +119,7 @@ impl ProvisionedEnv {
             capture_container_ids: Vec::new(),
             host_ips: Vec::new(),
             host_containers: Vec::new(),
+            vms: Vec::new(),
         };
 
         let run_id = generate_run_id();
@@ -144,6 +148,7 @@ impl ProvisionedEnv {
         self.teardown_inner().await
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn setup(&mut self, scenario: &Scenario, pcap_dir: &Path, run_id: &str) -> Result<()> {
         let prefix = format!("{}-{run_id}", scenario.metadata.name);
         let mut pulled: HashSet<String> = HashSet::new();
@@ -165,26 +170,44 @@ impl ProvisionedEnv {
         }
 
         // Phase 2: Create host containers (once each) and connect
-        // multi-homed hosts to additional networks.
+        // multi-homed hosts to additional networks.  VM hosts are
+        // skipped here and provisioned in Phase 4.
         let mut created: HashMap<String, String> = HashMap::new();
+        let mut vm_seen: HashSet<String> = HashSet::new();
         for state in &segments {
             for (host_name, ip) in &state.ips {
+                // Multi-homed Docker host.
                 if let Some(container_id) = created.get(host_name) {
                     connect_container(&self.docker, &state.net_name, container_id, *ip).await?;
-                    // Record the secondary IP for this multi-homed host.
                     if let Some((_, ips)) =
                         self.host_ips.iter_mut().find(|(name, _)| name == host_name)
                     {
                         ips.push(*ip);
                     }
-                } else {
-                    let host = scenario
-                        .infrastructure
-                        .hosts
-                        .iter()
-                        .find(|h| h.name == *host_name)
-                        .with_context(|| format!("host '{host_name}' not in scenario"))?;
+                    continue;
+                }
 
+                // Scenario validation rejects VM hosts in multiple
+                // segments, so this is unreachable in normal use.
+                if vm_seen.contains(host_name) {
+                    bail!(
+                        "VM host '{host_name}' appears in multiple segments; \
+                         multi-segment VM provisioning is not yet supported"
+                    );
+                }
+
+                let host = scenario
+                    .infrastructure
+                    .hosts
+                    .iter()
+                    .find(|h| h.name == *host_name)
+                    .with_context(|| format!("host '{host_name}' not in scenario"))?;
+
+                if host.is_vm() {
+                    // Track the VM host; actual provisioning in Phase 4.
+                    vm_seen.insert(host_name.clone());
+                    self.host_ips.push((host_name.clone(), vec![*ip]));
+                } else {
                     if pulled.insert(host.image.clone()) {
                         pull_image(&self.docker, &host.image).await?;
                     }
@@ -238,10 +261,52 @@ impl ProvisionedEnv {
             self.capture_container_ids.push(capture_id);
         }
 
+        // Phase 4: Provision libvirt VMs for Windows hosts.
+        for host in &scenario.infrastructure.hosts {
+            let Some(vm_config) = &host.vm else {
+                continue;
+            };
+
+            // Find the primary segment and bridge for this VM.
+            let (seg_name, bridge, test_ip, subnet) = segments
+                .iter()
+                .zip(&scenario.infrastructure.network.segments)
+                .find_map(|(state, seg)| {
+                    state
+                        .ips
+                        .iter()
+                        .find(|(name, _)| *name == host.name)
+                        .map(|(_, ip)| (seg.name.clone(), state.bridge.clone(), *ip, &seg.subnet))
+                })
+                .with_context(|| format!("VM host '{}' not found in any segment", host.name))?;
+
+            let net: ipnet::Ipv4Net = subnet
+                .parse()
+                .with_context(|| format!("invalid subnet '{}' for VM '{}'", subnet, host.name))?;
+            let prefix_len = net.prefix_len();
+            let gateway = Ipv4Addr::from(u32::from(net.network()) + 1);
+
+            println!("  Provisioning VM '{}' on segment '{seg_name}'…", host.name);
+            let provisioned_vm = vm::create_vm(
+                &host.name, vm_config, &prefix, &bridge, test_ip, prefix_len, gateway,
+            )
+            .await?;
+            println!(
+                "  VM '{}' ready (mgmt: {}, test: {test_ip})",
+                host.name, provisioned_vm.mgmt_ip,
+            );
+            self.vms.push(provisioned_vm);
+        }
+
         Ok(())
     }
 
     async fn teardown_inner(&self) -> Result<()> {
+        // Destroy VMs first.
+        for provisioned_vm in &self.vms {
+            let _ = vm::destroy_vm(provisioned_vm).await;
+        }
+
         let opts = RemoveContainerOptions {
             force: true,
             ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,11 @@ mod infra;
 mod meta;
 mod pcap;
 mod scenario;
+mod sysmon;
 #[cfg(test)]
 mod test_util;
 mod validator;
+mod vm;
 
 #[derive(Parser)]
 #[command(
@@ -112,10 +114,18 @@ async fn setup_run_and_assemble(
     output_dir: &Path,
     start: chrono::DateTime<chrono::Utc>,
 ) -> Result<()> {
+    // Install Sysmon on VMs that have it enabled.
+    for vm_host in &env.vms {
+        if vm_host.sysmon {
+            sysmon::install_and_configure(vm_host).await?;
+        }
+    }
+
     activity::run_setup(
         &env.docker,
         &scenario.infrastructure.hosts,
         &env.host_containers,
+        &env.vms,
     )
     .await?;
 
@@ -126,6 +136,7 @@ async fn setup_run_and_assemble(
         &env.host_ips,
         &scenario.activities,
         start,
+        &env.vms,
     )
     .await?;
     println!("Executed {} activity(ies)", executions.len());
@@ -143,6 +154,18 @@ async fn setup_run_and_assemble(
         failures.join("\n  "),
     );
 
+    // Collect Sysmon logs from VMs before stopping collectors.
+    let mut telemetry: Vec<(String, String)> = Vec::new();
+    for vm_host in &env.vms {
+        if vm_host.sysmon {
+            let rel_path = sysmon::collect_logs(vm_host, output_dir).await?;
+            telemetry.push((
+                vm_host.host_name.clone(),
+                rel_path.to_string_lossy().into_owned(),
+            ));
+        }
+    }
+
     // Stop capture containers so pcap files are flushed and complete.
     env.stop_collectors().await?;
     println!("Stopped collectors");
@@ -156,6 +179,7 @@ async fn setup_run_and_assemble(
         &env.host_ips,
         start,
         &mut executions,
+        &telemetry,
     )
 }
 
@@ -171,6 +195,7 @@ fn assemble_bundle(
     host_ips: &[(String, Vec<std::net::Ipv4Addr>)],
     start: chrono::DateTime<chrono::Utc>,
     executions: &mut [activity::Execution],
+    telemetry: &[(String, String)],
 ) -> Result<()> {
     let net_dir = output_dir.join("net");
     pcap::enrich_src_ports(&net_dir, executions)?;
@@ -183,7 +208,14 @@ fn assemble_bundle(
         || scenario_path.to_owned(),
         |n| n.to_string_lossy().into_owned(),
     );
-    meta::write(output_dir, &scenario_filename, scenario, host_ips, start)?;
+    meta::write(
+        output_dir,
+        &scenario_filename,
+        scenario,
+        host_ips,
+        start,
+        telemetry,
+    )?;
     println!("Wrote meta.json");
 
     Ok(())
@@ -310,6 +342,7 @@ mod tests {
             &host_ips,
             start,
             &mut executions,
+            &[],
         )
         .unwrap();
 
@@ -361,6 +394,7 @@ mod tests {
             &host_ips,
             start,
             &mut executions,
+            &[],
         )
         .unwrap();
 
@@ -412,6 +446,7 @@ mod tests {
             &host_ips,
             start,
             &mut executions,
+            &[],
         )
         .unwrap();
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -17,8 +17,9 @@ pub(crate) fn write(
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
     start: DateTime<Utc>,
+    telemetry: &[(String, String)],
 ) -> Result<()> {
-    let meta = build(scenario_filename, scenario, host_ips, start)?;
+    let meta = build(scenario_filename, scenario, host_ips, start, telemetry)?;
     let json = serde_json::to_string_pretty(&meta).context("failed to serialise meta.json")?;
     let path = output_dir.join("meta.json");
     fs::write(&path, json).with_context(|| format!("failed to write {}", path.display()))?;
@@ -30,6 +31,7 @@ fn build(
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
     start: DateTime<Utc>,
+    telemetry: &[(String, String)],
 ) -> Result<BundleMeta> {
     let total_duration = scenario::parse_duration(&scenario.duration)?;
     let end = start + total_duration;
@@ -65,6 +67,15 @@ fn build(
         })
         .collect();
 
+    let host_telemetry: Vec<MetaTelemetryEntry> = telemetry
+        .iter()
+        .map(|(host, path)| MetaTelemetryEntry {
+            host: host.clone(),
+            kind: "sysmon".to_owned(),
+            path: path.clone(),
+        })
+        .collect();
+
     Ok(BundleMeta {
         schema_version: SCHEMA_VERSION.to_owned(),
         scenario: scenario_filename.to_owned(),
@@ -96,6 +107,7 @@ fn build(
                 })
                 .collect(),
         },
+        host_telemetry,
     })
 }
 
@@ -114,6 +126,8 @@ struct BundleMeta {
     hosts: Vec<MetaHost>,
     network: MetaNetwork,
     capture: MetaCapture,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    host_telemetry: Vec<MetaTelemetryEntry>,
 }
 
 #[derive(Debug, Serialize)]
@@ -162,6 +176,13 @@ struct MetaPcapEntry {
     path: String,
 }
 
+#[derive(Debug, Serialize)]
+struct MetaTelemetryEntry {
+    host: String,
+    kind: String,
+    path: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -187,7 +208,7 @@ mod tests {
     #[test]
     fn build_meta_matches_expected_structure() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
 
         assert_eq!(meta.schema_version, "1");
         assert_eq!(meta.scenario, "ac-0.scenario.yaml");
@@ -211,7 +232,7 @@ mod tests {
     #[test]
     fn build_meta_json_roundtrip() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -225,7 +246,7 @@ mod tests {
     #[test]
     fn build_meta_matches_ac0_reference() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap();
+        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
         let actual: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&meta).unwrap()).unwrap();
 
@@ -245,6 +266,7 @@ mod tests {
             &scenario,
             &host_ips,
             start,
+            &[],
         )
         .unwrap();
 
@@ -262,7 +284,7 @@ mod tests {
         let (scenario, _, start) = ac0_test_inputs();
         let host_ips = vec![("ghost-host".to_owned(), vec![Ipv4Addr::new(10, 100, 0, 99)])];
 
-        let err = build("ac-0.scenario.yaml", &scenario, &host_ips, start).unwrap_err();
+        let err = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap_err();
         assert!(
             err.to_string().contains("not found in scenario"),
             "unexpected error: {err}",

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -74,9 +74,53 @@ pub(crate) struct Host {
     pub(crate) name: String,
     pub(crate) os: Os,
     pub(crate) role: Role,
+    #[serde(default)]
     pub(crate) image: String,
     #[serde(default)]
+    pub(crate) vm: Option<VmConfig>,
+    #[serde(default)]
     pub(crate) setup: Vec<String>,
+}
+
+impl Host {
+    /// Returns `true` if this host is provisioned as a libvirt VM.
+    pub(crate) fn is_vm(&self) -> bool {
+        self.vm.is_some()
+    }
+}
+
+/// Configuration for a libvirt-managed virtual machine.
+#[derive(Debug, Deserialize)]
+pub(crate) struct VmConfig {
+    /// Path to the qcow2 base image on the host.
+    pub(crate) base_image: String,
+    /// RAM in megabytes (default: 4096).
+    #[serde(default = "VmConfig::default_memory_mb")]
+    pub(crate) memory_mb: u32,
+    /// Number of virtual CPUs (default: 2).
+    #[serde(default = "VmConfig::default_vcpus")]
+    pub(crate) vcpus: u8,
+    /// SSH user for remote command execution.
+    pub(crate) ssh_user: String,
+    /// SSH password (used with sshpass).
+    pub(crate) ssh_password: String,
+    /// Whether to install and collect Sysmon telemetry (default: true).
+    #[serde(default = "VmConfig::default_sysmon")]
+    pub(crate) sysmon: bool,
+}
+
+impl VmConfig {
+    fn default_memory_mb() -> u32 {
+        4096
+    }
+
+    fn default_vcpus() -> u8 {
+        2
+    }
+
+    fn default_sysmon() -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -258,6 +302,30 @@ impl Scenario {
                 "duplicate host name '{}'",
                 host.name,
             );
+
+            if let Some(vm) = &host.vm {
+                ensure!(
+                    !vm.base_image.is_empty(),
+                    "VM host '{}' requires a non-empty base_image",
+                    host.name,
+                );
+                ensure!(
+                    vm.memory_mb >= 512,
+                    "VM host '{}' requires at least 512 MB of memory",
+                    host.name,
+                );
+                ensure!(
+                    vm.vcpus >= 1,
+                    "VM host '{}' requires at least 1 vCPU",
+                    host.name,
+                );
+            } else {
+                ensure!(
+                    !host.image.is_empty(),
+                    "host '{}' requires a Docker image (or a 'vm' config for VMs)",
+                    host.name,
+                );
+            }
         }
 
         let mut segment_names = HashSet::new();
@@ -280,6 +348,30 @@ impl Scenario {
                     segment.name,
                 );
             }
+        }
+
+        // VM hosts must appear in exactly one segment (multi-NIC VM
+        // provisioning is not yet supported).
+        let vm_hosts: HashSet<&str> = self
+            .infrastructure
+            .hosts
+            .iter()
+            .filter(|h| h.is_vm())
+            .map(|h| h.name.as_str())
+            .collect();
+        for vm_name in &vm_hosts {
+            let count = self
+                .infrastructure
+                .network
+                .segments
+                .iter()
+                .filter(|seg| seg.hosts.iter().any(|h| h == vm_name))
+                .count();
+            ensure!(
+                count <= 1,
+                "VM host '{vm_name}' appears in {count} segments, \
+                 but multi-segment VM provisioning is not yet supported",
+            );
         }
 
         for a in &self.activities.normal {
@@ -1217,5 +1309,174 @@ activities:
             err.to_string().contains("unsupported scenario version"),
             "unexpected error: {err}",
         );
+    }
+
+    // ── VM / Windows host tests ───────────────────────────────────
+
+    const AC2_YAML: &str = include_str!("../scenarios/ac-2-windows.scenario.yaml");
+
+    #[test]
+    fn ac2_windows_parses_and_validates() {
+        let s: Scenario = serde_yaml::from_str(AC2_YAML).unwrap();
+        s.validate().unwrap();
+        assert_eq!(s.metadata.name, "ac-2-windows");
+        assert_eq!(s.infrastructure.hosts.len(), 2);
+    }
+
+    #[test]
+    fn ac2_windows_host_has_vm_config() {
+        let s: Scenario = serde_yaml::from_str(AC2_YAML).unwrap();
+        let win = &s.infrastructure.hosts[1];
+        assert_eq!(win.name, "win-target-001");
+        assert_eq!(win.os, Os::Windows);
+        assert!(win.is_vm(), "Windows host must have VM config");
+        let vm = win.vm.as_ref().unwrap();
+        assert_eq!(vm.memory_mb, 4096);
+        assert_eq!(vm.vcpus, 2);
+        assert_eq!(vm.ssh_user, "admin");
+        assert!(vm.sysmon);
+    }
+
+    #[test]
+    fn ac2_linux_host_is_not_vm() {
+        let s: Scenario = serde_yaml::from_str(AC2_YAML).unwrap();
+        let linux = &s.infrastructure.hosts[0];
+        assert_eq!(linux.name, "attacker-001");
+        assert!(!linux.is_vm());
+    }
+
+    #[test]
+    fn reject_vm_host_without_base_image() {
+        let yaml = "\
+version: '1'
+metadata:
+  name: test
+  description: test
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+duration: 1m
+infrastructure:
+  hosts:
+    - name: h1
+      os: windows
+      role: target
+      vm:
+        base_image: ''
+        ssh_user: admin
+        ssh_password: pw
+  network:
+    segments:
+      - name: net
+        subnet: 10.0.0.0/24
+        hosts:
+          - h1
+activities:
+  normal: []
+  attack: []
+";
+        let s: Scenario = serde_yaml::from_str(yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("non-empty base_image"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn reject_non_vm_host_without_image() {
+        let yaml = "\
+version: '1'
+metadata:
+  name: test
+  description: test
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+duration: 1m
+infrastructure:
+  hosts:
+    - name: h1
+      os: linux
+      role: target
+  network:
+    segments:
+      - name: net
+        subnet: 10.0.0.0/24
+        hosts:
+          - h1
+activities:
+  normal: []
+  attack: []
+";
+        let s: Scenario = serde_yaml::from_str(yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("requires a Docker image"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn reject_vm_host_in_multiple_segments() {
+        let yaml = "\
+version: '1'
+metadata:
+  name: test
+  description: test
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+duration: 1m
+infrastructure:
+  hosts:
+    - name: win
+      os: windows
+      role: target
+      vm:
+        base_image: /images/win.qcow2
+        ssh_user: admin
+        ssh_password: pw
+    - name: linux
+      os: linux
+      role: attacker
+      image: alpine:3.19
+  network:
+    segments:
+      - name: dmz
+        subnet: 10.0.0.0/24
+        hosts:
+          - win
+          - linux
+      - name: internal
+        subnet: 10.1.0.0/24
+        hosts:
+          - win
+activities:
+  normal: []
+  attack: []
+";
+        let s: Scenario = serde_yaml::from_str(yaml).unwrap();
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("multi-segment VM provisioning is not yet supported"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn accept_vm_host_in_single_segment() {
+        let s: Scenario = serde_yaml::from_str(AC2_YAML).unwrap();
+        s.validate().unwrap();
     }
 }

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -1,0 +1,161 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::vm::{self, ProvisionedVm};
+
+/// Minimal Sysmon configuration (SwiftOnSecurity-inspired baseline).
+///
+/// Captures process creation, network connections, file creation, and
+/// registry modifications — the core events useful for threat detection
+/// datasets.
+const SYSMON_CONFIG_XML: &str = r#"<Sysmon schemaversion="4.90">
+  <EventFiltering>
+    <!-- Event ID 1: Process Create -->
+    <ProcessCreate onmatch="exclude" />
+    <!-- Event ID 3: Network Connection -->
+    <NetworkConnect onmatch="exclude" />
+    <!-- Event ID 11: File Create -->
+    <FileCreate onmatch="exclude" />
+    <!-- Event ID 13: Registry Value Set -->
+    <RegistryEvent onmatch="exclude" />
+  </EventFiltering>
+</Sysmon>"#;
+
+/// Installs Sysmon with a baseline configuration on a Windows VM.
+///
+/// Assumes the base VM image has Sysmon64.exe pre-installed at
+/// `C:\Sysmon\Sysmon64.exe`. Writes the config XML and runs the
+/// installer with `-accepteula -i`.
+pub(crate) async fn install_and_configure(vm_host: &ProvisionedVm) -> Result<()> {
+    // Write config XML to the VM.
+    let escaped_xml = SYSMON_CONFIG_XML.replace('\'', "''");
+    let write_cmd = format!(
+        "powershell -Command \"Set-Content \
+         -Path 'C:\\sysmon-config.xml' \
+         -Value '{escaped_xml}'\""
+    );
+    let code = vm::exec_ssh(
+        &vm_host.mgmt_ip,
+        &vm_host.ssh_user,
+        &vm_host.ssh_password,
+        &write_cmd,
+    )
+    .await
+    .context("failed to write Sysmon config")?;
+    if code != 0 {
+        bail!(
+            "writing Sysmon config on '{}' exited with code {code}",
+            vm_host.host_name,
+        );
+    }
+
+    // Install Sysmon with the config.
+    let install_cmd =
+        "powershell -Command \"& 'C:\\Sysmon\\Sysmon64.exe' -accepteula -i C:\\sysmon-config.xml\"";
+    let code = vm::exec_ssh(
+        &vm_host.mgmt_ip,
+        &vm_host.ssh_user,
+        &vm_host.ssh_password,
+        install_cmd,
+    )
+    .await
+    .context("failed to install Sysmon")?;
+    if code != 0 {
+        bail!(
+            "Sysmon installation on '{}' exited with code {code}",
+            vm_host.host_name,
+        );
+    }
+
+    println!("  Sysmon installed on {}", vm_host.host_name);
+    Ok(())
+}
+
+/// Exports Sysmon event logs as JSONL and downloads the file to the
+/// bundle's `host/<hostname>/sysmon.jsonl`.
+///
+/// Returns the relative path within the bundle (e.g.
+/// `host/win-target-001/sysmon.jsonl`).
+pub(crate) async fn collect_logs(vm_host: &ProvisionedVm, output_dir: &Path) -> Result<PathBuf> {
+    let host_dir = output_dir.join("host").join(&vm_host.host_name);
+
+    // Export Sysmon event log as JSONL via PowerShell.
+    let export_cmd = "powershell -Command \"\
+        Get-WinEvent -LogName 'Microsoft-Windows-Sysmon/Operational' \
+        -ErrorAction SilentlyContinue | \
+        ForEach-Object { $_ | ConvertTo-Json -Compress } | \
+        Set-Content -Path 'C:\\sysmon_export.jsonl'\"";
+    let code = vm::exec_ssh(
+        &vm_host.mgmt_ip,
+        &vm_host.ssh_user,
+        &vm_host.ssh_password,
+        export_cmd,
+    )
+    .await
+    .context("failed to export Sysmon logs")?;
+    if code != 0 {
+        bail!(
+            "Sysmon log export on '{}' exited with code {code}",
+            vm_host.host_name,
+        );
+    }
+
+    // Download the exported JSONL file.
+    let local_path = host_dir.join("sysmon.jsonl");
+    vm::scp_from(vm_host, "C:\\sysmon_export.jsonl", &local_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to download sysmon.jsonl from '{}'",
+                vm_host.host_name,
+            )
+        })?;
+
+    // Return relative path within the bundle.
+    let relative = PathBuf::from("host")
+        .join(&vm_host.host_name)
+        .join("sysmon.jsonl");
+    println!(
+        "  Collected Sysmon logs from {} -> {}",
+        vm_host.host_name,
+        relative.display(),
+    );
+    Ok(relative)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_xml_is_well_formed_sysmon_element() {
+        assert!(
+            SYSMON_CONFIG_XML.starts_with("<Sysmon "),
+            "config must start with a Sysmon element",
+        );
+        assert!(
+            SYSMON_CONFIG_XML.ends_with("</Sysmon>"),
+            "config must end with closing Sysmon tag",
+        );
+    }
+
+    #[test]
+    fn config_xml_contains_expected_event_filters() {
+        assert!(SYSMON_CONFIG_XML.contains("ProcessCreate"));
+        assert!(SYSMON_CONFIG_XML.contains("NetworkConnect"));
+        assert!(SYSMON_CONFIG_XML.contains("FileCreate"));
+        assert!(SYSMON_CONFIG_XML.contains("RegistryEvent"));
+    }
+
+    #[test]
+    fn config_xml_has_no_single_quotes() {
+        // The XML is embedded in a PowerShell single-quoted string.
+        // Single quotes inside would need escaping (''), so verify
+        // none are present to avoid broken commands.
+        assert!(
+            !SYSMON_CONFIG_XML.contains('\''),
+            "config XML must not contain single quotes (breaks PowerShell embedding)",
+        );
+    }
+}

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -166,6 +166,11 @@ pub(crate) fn run(bundle: &Path) -> Result<Report> {
         validate_l4_lite(bundle, &gt_records, &mut checks);
     }
 
+    // L1-005 + L2-006: host telemetry files
+    if let Some(m) = &meta {
+        validate_host_telemetry(bundle, m, &mut checks);
+    }
+
     checks.sort_by_key(|c| c.id);
     Ok(Report::new(checks))
 }
@@ -575,6 +580,76 @@ fn check_l3_hosts(meta: &Value, records: &[Value], checks: &mut Vec<Check>) {
         checks.push(fail(
             "L3-008",
             format!("unknown hosts: {}", unknown.join("; ")),
+        ));
+    }
+}
+
+// ── L1-005 + L2-006: host telemetry ─────────────────────────
+
+/// Validates host telemetry files referenced in meta.json.
+///
+/// Checks are skipped silently when no `host_telemetry` array is
+/// present, so Docker-only bundles remain valid without warnings.
+fn validate_host_telemetry(bundle: &Path, meta: &Value, checks: &mut Vec<Check>) {
+    let Some(entries) = meta.get("host_telemetry").and_then(Value::as_array) else {
+        return;
+    };
+    if entries.is_empty() {
+        return;
+    }
+
+    // L1-005: all referenced telemetry files exist.
+    let mut missing = Vec::new();
+    let mut existing_paths = Vec::new();
+    for entry in entries {
+        let Some(path_str) = entry.get("path").and_then(Value::as_str) else {
+            continue;
+        };
+        if bundle.join(path_str).exists() {
+            existing_paths.push(path_str);
+        } else {
+            missing.push(path_str);
+        }
+    }
+
+    if missing.is_empty() && !existing_paths.is_empty() {
+        checks.push(pass(
+            "L1-005",
+            format!("all {} telemetry file(s) exist", existing_paths.len()),
+        ));
+    } else if !missing.is_empty() {
+        checks.push(fail(
+            "L1-005",
+            format!("telemetry files not found: {}", missing.join(", ")),
+        ));
+    }
+
+    // L2-006: each telemetry JSONL file contains valid JSON lines.
+    let mut bad_files = Vec::new();
+    for path_str in &existing_paths {
+        let full_path = bundle.join(path_str);
+        if let Ok(content) = fs::read_to_string(&full_path) {
+            let has_bad_line = content
+                .lines()
+                .filter(|l| !l.is_empty())
+                .any(|l| serde_json::from_str::<Value>(l).is_err());
+            if has_bad_line {
+                bad_files.push(*path_str);
+            }
+        } else {
+            bad_files.push(*path_str);
+        }
+    }
+
+    if bad_files.is_empty() && !existing_paths.is_empty() {
+        checks.push(pass(
+            "L2-006",
+            "all telemetry JSONL files contain valid JSON",
+        ));
+    } else if !bad_files.is_empty() {
+        checks.push(fail(
+            "L2-006",
+            format!("invalid JSON in telemetry files: {}", bad_files.join(", ")),
         ));
     }
 }
@@ -1435,5 +1510,86 @@ mod tests {
         ] {
             assert_pass(&report, id);
         }
+    }
+
+    // ── L1-005 + L2-006: host telemetry ──────────────────────────
+
+    #[test]
+    fn telemetry_checks_skipped_when_no_host_telemetry() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        // No L1-005 or L2-006 checks should appear at all.
+        assert!(
+            find_check(&report, "L1-005").is_none(),
+            "L1-005 should be absent when no host_telemetry",
+        );
+        assert!(
+            find_check(&report, "L2-006").is_none(),
+            "L2-006 should be absent when no host_telemetry",
+        );
+    }
+
+    #[test]
+    fn telemetry_files_pass_when_present_and_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+
+        // Add host_telemetry to meta.json.
+        let meta_path = dir.path().join("meta.json");
+        let mut meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        meta["host_telemetry"] = serde_json::json!([
+            {"host": "target-001", "kind": "sysmon", "path": "host/target-001/sysmon.jsonl"}
+        ]);
+        fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();
+
+        // Create the sysmon.jsonl file with valid JSON.
+        let sysmon_path = dir.path().join("host/target-001/sysmon.jsonl");
+        fs::write(&sysmon_path, "{\"EventID\":1}\n{\"EventID\":3}\n").unwrap();
+
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-005");
+        assert_pass(&report, "L2-006");
+    }
+
+    #[test]
+    fn missing_telemetry_file_fails_l1_005() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+
+        let meta_path = dir.path().join("meta.json");
+        let mut meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        meta["host_telemetry"] = serde_json::json!([
+            {"host": "target-001", "kind": "sysmon", "path": "host/target-001/sysmon.jsonl"}
+        ]);
+        fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();
+
+        // Do NOT create the file.
+        let report = run(dir.path()).unwrap();
+        assert_fail(&report, "L1-005");
+    }
+
+    #[test]
+    fn invalid_telemetry_json_fails_l2_006() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+
+        let meta_path = dir.path().join("meta.json");
+        let mut meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        meta["host_telemetry"] = serde_json::json!([
+            {"host": "target-001", "kind": "sysmon", "path": "host/target-001/sysmon.jsonl"}
+        ]);
+        fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();
+
+        // Write invalid JSON.
+        let sysmon_path = dir.path().join("host/target-001/sysmon.jsonl");
+        fs::write(&sysmon_path, "not valid json\n").unwrap();
+
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-005");
+        assert_fail(&report, "L2-006");
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,391 @@
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use tokio::process::Command;
+
+use crate::scenario::VmConfig;
+
+/// Maximum time to wait for the VM to obtain a DHCP management IP.
+const DHCP_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Maximum time to wait for SSH to become reachable.
+const SSH_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Interval between SSH readiness polls.
+const SSH_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Represents a provisioned libvirt VM.
+pub(crate) struct ProvisionedVm {
+    /// Libvirt domain name (e.g. "mf-ac2-abc123-win-target-001").
+    pub(crate) domain_name: String,
+    /// Scenario host name.
+    pub(crate) host_name: String,
+    /// Path to the qcow2 overlay (deleted on teardown).
+    pub(crate) overlay_path: PathBuf,
+    /// Management IP on the libvirt default NAT network (for SSH).
+    pub(crate) mgmt_ip: Ipv4Addr,
+    /// SSH user.
+    pub(crate) ssh_user: String,
+    /// SSH password.
+    pub(crate) ssh_password: String,
+    /// Whether Sysmon telemetry should be collected.
+    pub(crate) sysmon: bool,
+}
+
+/// Creates and starts a libvirt VM connected to a Docker bridge.
+///
+/// The VM gets two NICs: one on the libvirt `default` network (for SSH
+/// management) and one on the specified Docker bridge (for scenario
+/// traffic). A qcow2 overlay is created on top of the base image so
+/// the original image is never modified.
+pub(crate) async fn create_vm(
+    host_name: &str,
+    vm_config: &VmConfig,
+    domain_prefix: &str,
+    bridge_name: &str,
+    test_ip: Ipv4Addr,
+    prefix_len: u8,
+    gateway: Ipv4Addr,
+) -> Result<ProvisionedVm> {
+    let domain_name = format!("mf-{domain_prefix}-{host_name}");
+    let overlay_path = std::env::temp_dir().join(format!("{domain_name}.qcow2"));
+
+    // Create a qcow2 overlay so the base image stays immutable.
+    let status = Command::new("qemu-img")
+        .args([
+            "create",
+            "-f",
+            "qcow2",
+            "-b",
+            &vm_config.base_image,
+            "-F",
+            "qcow2",
+        ])
+        .arg(&overlay_path)
+        .status()
+        .await
+        .context("failed to run qemu-img")?;
+    if !status.success() {
+        bail!("qemu-img create failed for {host_name}");
+    }
+
+    // Define and start the VM with two NICs.
+    let memory = vm_config.memory_mb.to_string();
+    let vcpus = vm_config.vcpus.to_string();
+    let status = Command::new("virt-install")
+        .args([
+            "--name",
+            &domain_name,
+            "--memory",
+            &memory,
+            "--vcpus",
+            &vcpus,
+            "--disk",
+        ])
+        .arg(format!("path={},format=qcow2", overlay_path.display()))
+        .args(["--import", "--network", "network=default", "--network"])
+        .arg(format!("bridge={bridge_name},model=virtio"))
+        .args(["--os-variant", "win10", "--noautoconsole", "--wait", "0"])
+        .status()
+        .await
+        .context("failed to run virt-install")?;
+    if !status.success() {
+        bail!("virt-install failed for {host_name}");
+    }
+
+    // Wait for the VM to get a DHCP address on the management network.
+    let mgmt_ip = resolve_mgmt_ip(&domain_name)
+        .await
+        .with_context(|| format!("failed to get management IP for {host_name}"))?;
+
+    // Wait for SSH to become reachable.
+    wait_ssh_ready(&mgmt_ip, &vm_config.ssh_user, &vm_config.ssh_password)
+        .await
+        .with_context(|| format!("SSH not reachable on {host_name} ({mgmt_ip})"))?;
+
+    // Resolve the MAC address of the scenario NIC so we can identify
+    // the correct adapter inside the Windows guest.
+    let scenario_mac = resolve_scenario_mac(&domain_name, bridge_name)
+        .await
+        .with_context(|| format!("failed to get scenario NIC MAC for {host_name}"))?;
+
+    // Windows represents MACs with hyphens in upper-case.
+    let win_mac = scenario_mac.to_uppercase().replace(':', "-");
+
+    // Configure the test network interface by matching its MAC address
+    // instead of relying on a hard-coded interface alias.
+    let configure_cmd = format!(
+        "powershell -Command \"\
+         $mac = '{win_mac}'; \
+         $adapter = Get-NetAdapter | Where-Object {{ $_.MacAddress -eq $mac }}; \
+         if (-not $adapter) {{ Write-Error 'no adapter with MAC {win_mac}'; exit 1 }}; \
+         New-NetIPAddress \
+           -InterfaceIndex $adapter.InterfaceIndex \
+           -IPAddress {test_ip} \
+           -PrefixLength {prefix_len} \
+           -DefaultGateway {gateway}\""
+    );
+    let code = exec_ssh(
+        &mgmt_ip,
+        &vm_config.ssh_user,
+        &vm_config.ssh_password,
+        &configure_cmd,
+    )
+    .await
+    .with_context(|| format!("failed to configure test NIC on {host_name}"))?;
+    if code != 0 {
+        bail!("test NIC configuration on '{host_name}' exited with code {code}");
+    }
+
+    Ok(ProvisionedVm {
+        domain_name,
+        host_name: host_name.to_owned(),
+        overlay_path,
+        mgmt_ip,
+        ssh_user: vm_config.ssh_user.clone(),
+        ssh_password: vm_config.ssh_password.clone(),
+        sysmon: vm_config.sysmon,
+    })
+}
+
+/// Destroys a libvirt VM and removes its overlay disk.
+pub(crate) async fn destroy_vm(vm: &ProvisionedVm) -> Result<()> {
+    let _ = Command::new("virsh")
+        .args(["destroy", &vm.domain_name])
+        .status()
+        .await;
+    let _ = Command::new("virsh")
+        .args(["undefine", &vm.domain_name, "--remove-all-storage"])
+        .status()
+        .await;
+
+    if vm.overlay_path.exists() {
+        let _ = std::fs::remove_file(&vm.overlay_path);
+    }
+    Ok(())
+}
+
+/// Executes a command on a VM via SSH and returns the exit code.
+pub(crate) async fn exec_ssh(
+    ip: &Ipv4Addr,
+    user: &str,
+    password: &str,
+    command: &str,
+) -> Result<i64> {
+    let output = Command::new("sshpass")
+        .args(["-p", password, "ssh"])
+        .args([
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
+        ])
+        .arg(format!("{user}@{ip}"))
+        .arg(command)
+        .output()
+        .await
+        .context("failed to run SSH command")?;
+
+    Ok(i64::from(output.status.code().unwrap_or(-1)))
+}
+
+/// Copies a file from a VM to the local filesystem via SCP.
+pub(crate) async fn scp_from(
+    vm: &ProvisionedVm,
+    remote_path: &str,
+    local_path: &std::path::Path,
+) -> Result<()> {
+    let status = Command::new("sshpass")
+        .args(["-p", &vm.ssh_password, "scp"])
+        .args([
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
+        ])
+        .arg(format!("{}@{}:{}", vm.ssh_user, vm.mgmt_ip, remote_path))
+        .arg(local_path)
+        .status()
+        .await
+        .context("failed to run SCP")?;
+
+    if !status.success() {
+        bail!("SCP from {}:{} failed", vm.mgmt_ip, remote_path);
+    }
+    Ok(())
+}
+
+/// Polls `virsh domifaddr` until a DHCP IP is assigned on the default
+/// network.
+async fn resolve_mgmt_ip(domain_name: &str) -> Result<Ipv4Addr> {
+    let deadline = tokio::time::Instant::now() + DHCP_TIMEOUT;
+
+    loop {
+        let output = Command::new("virsh")
+            .args(["domifaddr", domain_name, "--source", "lease"])
+            .output()
+            .await
+            .context("failed to run virsh domifaddr")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(ip) = parse_dhcp_ip(&stdout) {
+            return Ok(ip);
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            bail!(
+                "timeout waiting for DHCP IP for '{domain_name}' \
+                 (waited {}s)",
+                DHCP_TIMEOUT.as_secs()
+            );
+        }
+        tokio::time::sleep(SSH_POLL_INTERVAL).await;
+    }
+}
+
+/// Parses the first IPv4 address from `virsh domifaddr` output.
+///
+/// Example output line:
+/// ```text
+///  vnet0      52:54:00:xx:xx:xx    ipv4         192.168.122.123/24
+/// ```
+fn parse_dhcp_ip(output: &str) -> Option<Ipv4Addr> {
+    for line in output.lines() {
+        for token in line.split_whitespace() {
+            // Try stripping the CIDR prefix (e.g. "192.168.122.45/24").
+            let ip_str = token.find('/').map_or(token, |i| &token[..i]);
+            if let Ok(ip) = ip_str.parse::<Ipv4Addr>() {
+                return Some(ip);
+            }
+        }
+    }
+    None
+}
+
+/// Retrieves the MAC address of the NIC attached to the given bridge.
+///
+/// Parses `virsh domiflist` output to find the interface connected to
+/// the scenario bridge and returns its MAC address.
+async fn resolve_scenario_mac(domain_name: &str, bridge_name: &str) -> Result<String> {
+    let output = Command::new("virsh")
+        .args(["domiflist", domain_name])
+        .output()
+        .await
+        .context("failed to run virsh domiflist")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_bridge_mac(&stdout, bridge_name).with_context(|| {
+        format!("no NIC found on bridge '{bridge_name}' for domain '{domain_name}'")
+    })
+}
+
+/// Parses a MAC address from `virsh domiflist` output for a given bridge.
+///
+/// Example output:
+/// ```text
+///  Interface  Type       Source     Model       MAC
+/// -------------------------------------------------------
+///  vnet0      network    default    rtl8139     52:54:00:aa:bb:cc
+///  vnet1      bridge     mf-br1    virtio      52:54:00:dd:ee:ff
+/// ```
+fn parse_bridge_mac(output: &str, bridge_name: &str) -> Option<String> {
+    for line in output.lines() {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        // Expected columns: Interface, Type, Source, Model, MAC
+        if tokens.len() >= 5 && tokens[1] == "bridge" && tokens[2] == bridge_name {
+            return Some(tokens[4].to_owned());
+        }
+    }
+    None
+}
+
+/// Polls SSH connectivity until the VM is reachable.
+async fn wait_ssh_ready(ip: &Ipv4Addr, user: &str, password: &str) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + SSH_TIMEOUT;
+
+    loop {
+        let result = exec_ssh(ip, user, password, "echo ready").await;
+        if let Ok(0) = result {
+            return Ok(());
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            bail!(
+                "timeout waiting for SSH on {ip} (waited {}s)",
+                SSH_TIMEOUT.as_secs()
+            );
+        }
+        tokio::time::sleep(SSH_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dhcp_ip_typical_output() {
+        let output = " Name       MAC address          Protocol     Address\n\
+                       ---------------------------------------------------------------\n\
+                        vnet0      52:54:00:ab:cd:ef    ipv4         192.168.122.45/24\n";
+        assert_eq!(
+            parse_dhcp_ip(output),
+            Some(Ipv4Addr::new(192, 168, 122, 45)),
+        );
+    }
+
+    #[test]
+    fn parse_dhcp_ip_no_address() {
+        assert_eq!(parse_dhcp_ip(""), None);
+        assert_eq!(parse_dhcp_ip("Name   MAC   Protocol   Address\n"), None);
+    }
+
+    #[test]
+    fn parse_dhcp_ip_different_prefix() {
+        let output = " vnet0  52:54:00:ab:cd:ef  ipv4  10.0.0.5/16\n";
+        assert_eq!(parse_dhcp_ip(output), Some(Ipv4Addr::new(10, 0, 0, 5)));
+    }
+
+    // ── parse_bridge_mac tests ──────────────────────────────────
+
+    #[test]
+    fn parse_bridge_mac_finds_matching_bridge() {
+        let output = " Interface  Type       Source     Model       MAC\n\
+                       -------------------------------------------------------\n\
+                        vnet0      network    default    rtl8139     52:54:00:aa:bb:cc\n\
+                        vnet1      bridge     mf-br1     virtio      52:54:00:dd:ee:ff\n";
+        assert_eq!(
+            parse_bridge_mac(output, "mf-br1"),
+            Some("52:54:00:dd:ee:ff".to_owned()),
+        );
+    }
+
+    #[test]
+    fn parse_bridge_mac_no_match() {
+        let output = " Interface  Type       Source     Model       MAC\n\
+                       -------------------------------------------------------\n\
+                        vnet0      network    default    rtl8139     52:54:00:aa:bb:cc\n";
+        assert_eq!(parse_bridge_mac(output, "mf-br1"), None);
+    }
+
+    #[test]
+    fn parse_bridge_mac_empty_output() {
+        assert_eq!(parse_bridge_mac("", "mf-br1"), None);
+    }
+
+    #[test]
+    fn parse_bridge_mac_ignores_network_type() {
+        let output = " vnet0  network  mf-br1  rtl8139  52:54:00:aa:bb:cc\n";
+        assert_eq!(
+            parse_bridge_mac(output, "mf-br1"),
+            None,
+            "should only match type=bridge, not type=network",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add libvirt-based Windows VM provisioning (`src/vm.rs`) with qcow2 overlay, dual-NIC setup (management + scenario traffic), SSH/SCP command execution, and teardown
- Detect the scenario NIC inside the Windows guest dynamically by MAC address (via `virsh domiflist`) instead of relying on a hard-coded interface alias
- Install and configure Sysmon with a SwiftOnSecurity-inspired baseline, then export event logs as JSONL into the bundle at `host/<hostname>/sysmon.jsonl` (`src/sysmon.rs`)
- Extend activity execution and host setup to route through an SSH backend for VM-backed hosts while keeping Docker exec for containers
- Add `VmConfig` to the scenario schema with validation (base image, memory, vCPUs) and an `ac-2-windows` scenario exercising one Linux attacker + one Windows target with an nmap port scan
- Reject VM hosts that appear in multiple network segments (multi-NIC VM provisioning is not yet supported)
- Add `host_telemetry` array to `meta.json` and Validator checks L1-005 (telemetry files exist) and L2-006 (valid JSONL content)

Part of #19

## Test plan

- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` passes (196 tests, including new VM/Sysmon/telemetry tests)
- [x] `ac-2-windows.scenario.yaml` parses and validates correctly
- [x] VM host is detected via `is_vm()` and non-VM hosts remain unaffected
- [x] Scenario validation rejects VM hosts without `base_image` and non-VM hosts without `image`
- [x] Scenario validation rejects VM hosts appearing in multiple segments
- [x] `virsh domiflist` output parsing extracts the correct MAC for a given bridge
- [x] Sysmon config XML is well-formed and contains expected event filters
- [x] `virsh domifaddr` output parsing extracts IPv4 addresses correctly
- [x] Validator L1-005 passes when telemetry files exist and fails when missing
- [x] Validator L2-006 passes for valid JSONL and fails for invalid JSON
- [x] Docker-only bundles without `host_telemetry` skip telemetry checks silently
- [ ] E2E: provision a Windows VM, run the ac-2-windows scenario, and verify `sysmon.jsonl` appears in the bundle