### PR TITLE
Add Falco collection for Linux containers (#27)

### DIFF
--- a/scenarios/ac-2-tls.scenario.yaml
+++ b/scenarios/ac-2-tls.scenario.yaml
@@ -38,6 +38,7 @@ infrastructure:
       os: linux
       role: target
       image: alpine:3.19
+      falco: true
       setup:
         - "while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 3\\r\\n\\r\\nok\\n' | nc -l -p 80 > /dev/null; done &"
   network:

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1207,12 +1207,18 @@ mod tests {
 
         crate::pcap::enrich_src_ports(&net_dir, &mut results).unwrap();
 
-        // Both executions must have distinct, non-zero src_ports even
-        // though they share the same src_ip, dst_ip, and dst_port.
+        // Successful executions must have distinct, non-zero src_ports
+        // even though they share the same src_ip, dst_ip, and dst_port.
+        // Failed commands (e.g. curl exit-code 7) are skipped during
+        // pcap enrichment, so their src_port stays 0.
         let normal = results.iter().find(|e| e.attack.is_none()).unwrap();
         let attack = results.iter().find(|e| e.attack.is_some()).unwrap();
-        assert_ne!(normal.src_port, 0, "normal src_port must be enriched");
-        assert_ne!(attack.src_port, 0, "attack src_port must be enriched");
+        if normal.exit_code == 0 {
+            assert_ne!(normal.src_port, 0, "normal src_port must be enriched");
+        }
+        if attack.exit_code == 0 {
+            assert_ne!(attack.src_port, 0, "attack src_port must be enriched");
+        }
 
         crate::ground_truth::write(dir.path(), &results).unwrap();
 

--- a/src/falco.rs
+++ b/src/falco.rs
@@ -1,0 +1,161 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use bollard::Docker;
+use bollard::exec::CreateExecOptions;
+use bollard::models::ContainerStateStatusEnum;
+use futures_util::StreamExt;
+
+/// Output path inside the Falco sidecar container where JSONL events
+/// are written.
+pub(crate) const CONTAINER_OUTPUT_PATH: &str = "/var/log/falco.jsonl";
+
+/// Collects Falco JSONL output from a sidecar container into the
+/// bundle's `host/<hostname>/falco.jsonl`.
+///
+/// If the sidecar is no longer running (e.g. eBPF unavailable in CI)
+/// or produced no events, writes an empty file so the validator can
+/// surface it as a warning (`L2-009`) rather than aborting the whole
+/// bundle generation.
+///
+/// Returns the relative path within the bundle (e.g.
+/// `host/target-001/falco.jsonl`).
+pub(crate) async fn collect_logs(
+    docker: &Docker,
+    container_id: &str,
+    host_name: &str,
+    output_dir: &Path,
+) -> Result<PathBuf> {
+    let host_dir = output_dir.join("host").join(host_name);
+    let local_path = host_dir.join("falco.jsonl");
+    let relative = PathBuf::from("host").join(host_name).join("falco.jsonl");
+
+    // If the sidecar exited (e.g. eBPF probe failure), write an empty
+    // file so the validator can report L2-009 as a warning.
+    if !is_running(docker, container_id).await? {
+        eprintln!(
+            "  Warning: Falco sidecar for '{host_name}' is not running; \
+             writing empty falco.jsonl",
+        );
+        std::fs::write(&local_path, b"").with_context(|| {
+            format!(
+                "failed to write falco.jsonl for '{host_name}' at {}",
+                local_path.display(),
+            )
+        })?;
+        return Ok(relative);
+    }
+
+    // Copy the JSONL file out of the sidecar container via exec + cat.
+    let cat_cmd = format!("cat {CONTAINER_OUTPUT_PATH}");
+    let output = exec_output(docker, container_id, &cat_cmd)
+        .await
+        .with_context(|| format!("failed to collect Falco logs from '{host_name}'"))?;
+
+    if output.is_empty() {
+        eprintln!(
+            "  Warning: Falco log is empty for '{host_name}'; \
+             sidecar produced no events",
+        );
+    }
+
+    std::fs::write(&local_path, &output).with_context(|| {
+        format!(
+            "failed to write falco.jsonl for '{host_name}' at {}",
+            local_path.display(),
+        )
+    })?;
+
+    println!(
+        "  Collected Falco logs from {host_name} -> {}",
+        relative.display(),
+    );
+    Ok(relative)
+}
+
+/// Checks whether a container is currently running.
+async fn is_running(docker: &Docker, container_id: &str) -> Result<bool> {
+    let info = docker
+        .inspect_container(container_id, None)
+        .await
+        .with_context(|| format!("failed to inspect container '{container_id}'"))?;
+    let running = info
+        .state
+        .and_then(|s| s.status)
+        .is_some_and(|s| s == ContainerStateStatusEnum::RUNNING);
+    Ok(running)
+}
+
+/// Executes a command and captures its stdout as bytes.
+///
+/// Returns an error if the exec exits with a non-zero status code.
+async fn exec_output(docker: &Docker, container_id: &str, command: &str) -> Result<Vec<u8>> {
+    let config = CreateExecOptions {
+        cmd: Some(vec!["/bin/sh", "-c", command]),
+        attach_stdout: Some(true),
+        attach_stderr: Some(true),
+        ..Default::default()
+    };
+    let exec = docker
+        .create_exec(container_id, config)
+        .await
+        .context("failed to create exec instance")?;
+    let result = docker
+        .start_exec(&exec.id, None)
+        .await
+        .context("failed to start exec")?;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    if let bollard::exec::StartExecResults::Attached {
+        output: mut stream, ..
+    } = result
+    {
+        while let Some(Ok(chunk)) = stream.next().await {
+            match chunk {
+                bollard::container::LogOutput::StdOut { message } => {
+                    stdout.extend_from_slice(&message);
+                }
+                bollard::container::LogOutput::StdErr { message } => {
+                    stderr.extend_from_slice(&message);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let inspect = docker
+        .inspect_exec(&exec.id)
+        .await
+        .context("failed to inspect exec")?;
+    let exit_code = inspect.exit_code.unwrap_or(0);
+    if exit_code != 0 {
+        let err_msg = String::from_utf8_lossy(&stderr);
+        bail!("command exited with code {exit_code}: {command}\nstderr: {err_msg}",);
+    }
+
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_output_path_is_absolute() {
+        assert!(
+            CONTAINER_OUTPUT_PATH.starts_with('/'),
+            "Falco output path must be absolute inside the container",
+        );
+    }
+
+    #[test]
+    fn container_output_path_ends_with_jsonl() {
+        assert!(
+            Path::new(CONTAINER_OUTPUT_PATH)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl")),
+            "Falco output must use .jsonl extension",
+        );
+    }
+}

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -18,6 +18,7 @@ use crate::scenario::Scenario;
 use crate::vm;
 
 const CAPTURE_IMAGE: &str = "alpine:3.19";
+const FALCO_IMAGE: &str = "falcosecurity/falco-no-driver:0.39.2";
 const LINUX_IFNAMSIZ: usize = 15;
 
 /// Holds provisioned Docker resources, VMs, and assigned host IPs.
@@ -31,6 +32,8 @@ pub(crate) struct ProvisionedEnv {
     capture_container_ids: Vec<String>,
     pub(crate) host_ips: Vec<(String, Vec<Ipv4Addr>)>,
     pub(crate) host_containers: Vec<(String, String)>,
+    /// Falco sidecar containers: `(host_name, sidecar_container_id)`.
+    pub(crate) falco_containers: Vec<(String, String)>,
     /// Provisioned libvirt VMs (Windows hosts).
     pub(crate) vms: Vec<vm::ProvisionedVm>,
 }
@@ -119,6 +122,7 @@ impl ProvisionedEnv {
             capture_container_ids: Vec::new(),
             host_ips: Vec::new(),
             host_containers: Vec::new(),
+            falco_containers: Vec::new(),
             vms: Vec::new(),
         };
 
@@ -231,6 +235,31 @@ impl ProvisionedEnv {
                     self.host_ips.push((host_name.clone(), vec![*ip]));
                 }
             }
+        }
+
+        // Phase 2.5: Create privileged Falco sidecar containers for
+        // hosts with system-call monitoring enabled.  Each sidecar uses
+        // the official Falco image and shares the PID namespace of its
+        // target container so that the eBPF probes observe the target's
+        // processes.
+        for host in &scenario.infrastructure.hosts {
+            if !host.falco || host.is_vm() {
+                continue;
+            }
+            let Some(target_id) = created.get(&host.name) else {
+                continue;
+            };
+            if pulled.insert(FALCO_IMAGE.to_owned()) {
+                pull_image(&self.docker, FALCO_IMAGE).await?;
+            }
+            let sidecar_name = format!("mf-{prefix}-{}-falco", host.name);
+            let sidecar_id = create_falco_sidecar(&self.docker, &sidecar_name, target_id).await?;
+            self.docker
+                .start_container::<String>(&sidecar_id, None)
+                .await
+                .with_context(|| format!("failed to start Falco sidecar for '{}'", host.name))?;
+            self.container_ids.push(sidecar_id.clone());
+            self.falco_containers.push((host.name.clone(), sidecar_id));
         }
 
         // Phase 3: Start per-segment capture containers.
@@ -472,6 +501,48 @@ async fn create_capture_container(
         .create_container(Some(opts), config)
         .await
         .with_context(|| format!("failed to create capture container '{name}'"))?;
+    Ok(response.id)
+}
+
+/// Creates a privileged Falco sidecar container that shares the PID
+/// namespace of the target container and monitors system calls via
+/// `engine.kind=modern_ebpf`, writing JSONL events to a file.
+async fn create_falco_sidecar(
+    docker: &Docker,
+    name: &str,
+    target_container_id: &str,
+) -> Result<String> {
+    let output_path = crate::falco::CONTAINER_OUTPUT_PATH;
+    let config = Config {
+        image: Some(FALCO_IMAGE.to_owned()),
+        cmd: Some(vec![
+            "/usr/bin/falco".to_owned(),
+            "-o".to_owned(),
+            "engine.kind=modern_ebpf".to_owned(),
+            "-o".to_owned(),
+            "json_output=true".to_owned(),
+            "-o".to_owned(),
+            "file_output.enabled=true".to_owned(),
+            "-o".to_owned(),
+            format!("file_output.filename={output_path}"),
+            "-o".to_owned(),
+            "stdout_output.enabled=false".to_owned(),
+        ]),
+        host_config: Some(HostConfig {
+            privileged: Some(true),
+            pid_mode: Some(format!("container:{target_container_id}")),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let opts = CreateContainerOptions {
+        name: name.to_owned(),
+        ..Default::default()
+    };
+    let response = docker
+        .create_container(Some(opts), config)
+        .await
+        .with_context(|| format!("failed to create Falco sidecar '{name}'"))?;
     Ok(response.id)
 }
 
@@ -774,6 +845,77 @@ mod tests {
             pcap_path.exists(),
             "pcap file should exist after stopping collectors",
         );
+
+        env.down().await.unwrap();
+    }
+
+    /// Verifies the Falco sidecar container starts and stays running
+    /// with the configured flags — requires Docker.
+    #[tokio::test]
+    #[ignore = "requires Docker daemon"]
+    async fn falco_sidecar_stays_running() {
+        let mut scenario = load_ac0();
+        isolate_subnets(&mut scenario);
+        // Enable Falco on the target host.
+        scenario
+            .infrastructure
+            .hosts
+            .iter_mut()
+            .find(|h| h.name == "target-001")
+            .unwrap()
+            .falco = true;
+
+        let dir = tempfile::tempdir().unwrap();
+        let net_dir = dir.path().join("net");
+        std::fs::create_dir_all(&net_dir).unwrap();
+
+        let env = ProvisionedEnv::up(&scenario, &net_dir).await.unwrap();
+
+        assert_eq!(
+            env.falco_containers.len(),
+            1,
+            "one host has falco: true, so one Falco sidecar",
+        );
+        let (host_name, sidecar_id) = &env.falco_containers[0];
+        assert_eq!(host_name, "target-001");
+
+        // Give the sidecar a moment to either stay up or crash.
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        let info = env
+            .docker
+            .inspect_container(sidecar_id, None)
+            .await
+            .unwrap();
+        let status = info.state.unwrap().status.unwrap();
+
+        if status != bollard::models::ContainerStateStatusEnum::RUNNING {
+            // In CI environments without eBPF support (e.g. GitHub Actions
+            // runners), Falco exits when it cannot initialise the
+            // modern_ebpf engine.  Verify the exit was caused by a
+            // probe/driver issue, not by invalid configuration flags.
+            use bollard::container::LogsOptions;
+            let opts = LogsOptions::<String> {
+                stdout: true,
+                stderr: true,
+                ..Default::default()
+            };
+            let chunks: Vec<_> = env
+                .docker
+                .logs(sidecar_id, Some(opts))
+                .try_collect()
+                .await
+                .unwrap();
+            let log_output: String = chunks.iter().map(ToString::to_string).collect();
+            let lower = log_output.to_lowercase();
+            assert!(
+                lower.contains("bpf")
+                    || lower.contains("probe")
+                    || lower.contains("driver")
+                    || lower.contains("kernel"),
+                "Falco sidecar exited for unexpected reason (not eBPF):\n{log_output}",
+            );
+        }
 
         env.down().await.unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use clap::{Parser, Subcommand};
 
 mod activity;
+mod falco;
 mod ground_truth;
 mod infra;
 mod meta;
@@ -160,15 +161,26 @@ async fn setup_run_and_assemble(
     );
 
     // Collect Sysmon logs from VMs before stopping collectors.
-    let mut telemetry: Vec<(String, String)> = Vec::new();
+    let mut telemetry: Vec<(String, String, String)> = Vec::new();
     for vm_host in &env.vms {
         if vm_host.sysmon {
             let rel_path = sysmon::collect_logs(vm_host, output_dir).await?;
             telemetry.push((
                 vm_host.host_name.clone(),
+                "sysmon".to_owned(),
                 rel_path.to_string_lossy().into_owned(),
             ));
         }
+    }
+
+    // Collect Falco logs from sidecar containers.
+    for (host_name, falco_id) in &env.falco_containers {
+        let rel_path = falco::collect_logs(&env.docker, falco_id, host_name, output_dir).await?;
+        telemetry.push((
+            host_name.clone(),
+            "falco".to_owned(),
+            rel_path.to_string_lossy().into_owned(),
+        ));
     }
 
     // Stop capture containers so pcap files are flushed and complete.
@@ -200,7 +212,7 @@ fn assemble_bundle(
     host_ips: &[(String, Vec<std::net::Ipv4Addr>)],
     start: chrono::DateTime<chrono::Utc>,
     executions: &mut [activity::Execution],
-    telemetry: &[(String, String)],
+    telemetry: &[(String, String, String)],
 ) -> Result<()> {
     let net_dir = output_dir.join("net");
     pcap::enrich_src_ports(&net_dir, executions)?;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -19,7 +19,7 @@ pub(crate) fn write(
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
     start: DateTime<Utc>,
-    telemetry: &[(String, String)],
+    telemetry: &[(String, String, String)],
 ) -> Result<()> {
     let meta = build(scenario_filename, scenario, host_ips, start, telemetry)?;
     let json = serde_json::to_string_pretty(&meta).context("failed to serialise meta.json")?;
@@ -33,7 +33,7 @@ fn build(
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
     start: DateTime<Utc>,
-    telemetry: &[(String, String)],
+    telemetry: &[(String, String, String)],
 ) -> Result<BundleMeta> {
     let total_duration = scenario::parse_duration(&scenario.duration)?;
     let end = start + total_duration;
@@ -71,9 +71,9 @@ fn build(
 
     let host_telemetry: Vec<MetaTelemetryEntry> = telemetry
         .iter()
-        .map(|(host, path)| MetaTelemetryEntry {
+        .map(|(host, kind, path)| MetaTelemetryEntry {
             host: host.clone(),
-            kind: "sysmon".to_owned(),
+            kind: kind.clone(),
             path: path.clone(),
         })
         .collect();

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -26,6 +26,9 @@ const IP_PROTO_ICMP: u8 = 1;
 pub(crate) fn enrich_src_ports(net_dir: &Path, executions: &mut [Execution]) -> Result<()> {
     let mut packets = read_all_packets(net_dir)?;
     for exec in executions.iter_mut() {
+        if exec.exit_code != 0 {
+            continue;
+        }
         let start_us = exec.start.timestamp_micros();
         let end_us = exec.end.timestamp_micros() + 1_000_000;
         let idx = packets
@@ -487,6 +490,24 @@ mod tests {
             1000,
         )];
         assert!(enrich_src_ports(dir.path(), &mut execs).is_err());
+    }
+
+    #[test]
+    fn enrich_skips_failed_executions() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pcap(dir.path(), "capture.pcap", &[]);
+
+        let mut exec = make_execution(
+            Ipv4Addr::new(10, 0, 0, 2),
+            Ipv4Addr::new(10, 0, 0, 3),
+            80,
+            Protocol::Tcp,
+            1000,
+        );
+        exec.exit_code = 7;
+        let mut execs = vec![exec];
+        enrich_src_ports(dir.path(), &mut execs).unwrap();
+        assert_eq!(execs[0].src_port, 0);
     }
 
     #[test]

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -80,6 +80,11 @@ pub(crate) struct Host {
     pub(crate) vm: Option<VmConfig>,
     #[serde(default)]
     pub(crate) setup: Vec<String>,
+    /// Whether to install and collect Falco telemetry (default: false).
+    ///
+    /// Only applies to Linux container hosts.
+    #[serde(default)]
+    pub(crate) falco: bool,
 }
 
 impl Host {
@@ -1768,6 +1773,14 @@ activities:
         assert_eq!(s.environment.encryption, Encryption::Tls);
         assert_eq!(s.infrastructure.hosts.len(), 3);
         assert_eq!(s.infrastructure.network.segments.len(), 2);
+
+        let backend = s
+            .infrastructure
+            .hosts
+            .iter()
+            .find(|h| h.name == "backend-001")
+            .expect("backend-001 must exist");
+        assert!(backend.falco, "backend-001 must have Falco enabled");
     }
 
     #[test]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -238,6 +238,11 @@ pub(crate) fn run_with_config(bundle: &Path, config: &ValidatorConfig) -> Result
         Vec::new()
     };
 
+    // L1-007 + L2-009: Falco JSONL files
+    if let Some(m) = &meta {
+        validate_falco(bundle, m, &mut checks);
+    }
+
     // L4-002: GT process records ↔ Sysmon temporal overlap
     if !gt_records.is_empty() {
         validate_l4_sysmon(
@@ -787,20 +792,23 @@ fn validate_host_telemetry(bundle: &Path, meta: &Value, checks: &mut Vec<Check>)
         return;
     }
 
-    // Sysmon files are validated separately via L1-006 / L2-008, so
-    // exclude them here to avoid duplicate (and stricter) checks.
-    let non_sysmon: Vec<_> = entries
+    // Sysmon and Falco files are validated separately via their own
+    // L1/L2 checks, so exclude them here to avoid duplicate checks.
+    let generic: Vec<_> = entries
         .iter()
-        .filter(|e| e.get("kind").and_then(Value::as_str) != Some("sysmon"))
+        .filter(|e| {
+            let kind = e.get("kind").and_then(Value::as_str);
+            kind != Some("sysmon") && kind != Some("falco")
+        })
         .collect();
-    if non_sysmon.is_empty() {
+    if generic.is_empty() {
         return;
     }
 
     // L1-005: all referenced telemetry files exist.
     let mut missing = Vec::new();
     let mut existing_paths = Vec::new();
-    for entry in &non_sysmon {
+    for entry in &generic {
         let Some(path_str) = entry.get("path").and_then(Value::as_str) else {
             continue;
         };
@@ -941,6 +949,119 @@ fn validate_sysmon(
     }
 
     host_events
+}
+
+// ── L1-007 + L2-009: Falco JSONL files ───────────────────────
+
+/// Falco records must contain at least these fields to be useful.
+const FALCO_REQUIRED_FIELDS: &[&str] = &["time", "rule", "priority", "output"];
+
+/// Validates that Falco JSONL files declared in `host_telemetry`
+/// exist, contain valid JSON lines, and carry basic required fields.
+fn validate_falco(bundle: &Path, meta: &Value, checks: &mut Vec<Check>) {
+    let Some(entries) = meta.get("host_telemetry").and_then(Value::as_array) else {
+        return;
+    };
+
+    let falco_entries: Vec<_> = entries
+        .iter()
+        .filter(|e| e.get("kind").and_then(Value::as_str) == Some("falco"))
+        .collect();
+
+    if falco_entries.is_empty() {
+        return;
+    }
+
+    // L1-007: all Falco JSONL files exist.
+    let mut missing = Vec::new();
+    let mut existing_paths = Vec::new();
+    for entry in &falco_entries {
+        let Some(path_str) = entry.get("path").and_then(Value::as_str) else {
+            continue;
+        };
+        if bundle.join(path_str).is_file() {
+            existing_paths.push(path_str);
+        } else {
+            missing.push(path_str);
+        }
+    }
+
+    if missing.is_empty() && !existing_paths.is_empty() {
+        checks.push(pass(
+            "L1-007",
+            format!("all {} Falco JSONL file(s) exist", existing_paths.len()),
+        ));
+    } else if !missing.is_empty() {
+        checks.push(fail(
+            "L1-007",
+            format!("Falco JSONL files not found: {}", missing.join(", ")),
+        ));
+    }
+
+    // L2-009: each Falco JSONL file contains valid JSON lines with
+    // basic required fields.
+    let mut bad_files = Vec::new();
+    let mut empty_files = Vec::new();
+    let mut field_errors = Vec::new();
+    for path_str in &existing_paths {
+        let full_path = bundle.join(path_str);
+        match fs::read_to_string(&full_path) {
+            Ok(content) => {
+                let mut line_count: usize = 0;
+                let mut bad_count: usize = 0;
+                for (i, line) in content.lines().filter(|l| !l.is_empty()).enumerate() {
+                    line_count += 1;
+                    match serde_json::from_str::<Value>(line) {
+                        Ok(record) => {
+                            for field in FALCO_REQUIRED_FIELDS {
+                                if record.get(*field).is_none() {
+                                    field_errors.push(format!(
+                                        "{path_str} line {}: missing '{field}'",
+                                        i + 1,
+                                    ));
+                                }
+                            }
+                        }
+                        Err(_) => bad_count += 1,
+                    }
+                }
+                if line_count == 0 {
+                    empty_files.push(*path_str);
+                } else if bad_count > 0 {
+                    bad_files.push(format!("{path_str} ({bad_count} bad line(s))"));
+                }
+            }
+            Err(_) => {
+                bad_files.push((*path_str).to_owned());
+            }
+        }
+    }
+
+    if bad_files.is_empty()
+        && empty_files.is_empty()
+        && field_errors.is_empty()
+        && !existing_paths.is_empty()
+    {
+        checks.push(pass(
+            "L2-009",
+            "all Falco JSONL files contain valid JSON with required fields",
+        ));
+    } else if !empty_files.is_empty() {
+        checks.push(warn(
+            "L2-009",
+            format!("empty Falco JSONL (no events): {}", empty_files.join(", "),),
+        ));
+    } else if !bad_files.is_empty() {
+        checks.push(warn(
+            "L2-009",
+            format!("invalid JSON in Falco JSONL: {}", bad_files.join(", ")),
+        ));
+    } else if !field_errors.is_empty() {
+        checks.push(warn(
+            "L2-009",
+            format!("Falco records missing fields: {}", field_errors.join("; "),),
+        ));
+    }
 }
 
 // ── L4-001 ──────────────────────────────────────────────────
@@ -2915,5 +3036,148 @@ mod tests {
         // Packets are at exact second boundaries so they land within
         // [start_us, end_us] even with no tolerance.
         assert_pass(&report, "L4-001");
+    }
+
+    // ── L1-007 + L2-009: Falco JSONL ─────────────────────────────
+
+    fn falco_event(rule: &str) -> String {
+        format!(
+            r#"{{"time":"2026-01-15T09:01:00.000000000+0000","rule":"{rule}","priority":"Notice","output":"test event"}}"#,
+        )
+    }
+
+    fn meta_json_with_falco() -> String {
+        let mut meta: Value = serde_json::from_str(meta_json()).unwrap();
+        meta["host_telemetry"] = serde_json::json!([{
+            "host": "target-001",
+            "kind": "falco",
+            "path": "host/target-001/falco.jsonl"
+        }]);
+        serde_json::to_string_pretty(&meta).unwrap()
+    }
+
+    fn create_falco_bundle(dir: &Path) {
+        create_valid_bundle(dir);
+        fs::write(dir.join("meta.json"), meta_json_with_falco()).unwrap();
+        let falco = format!(
+            "{}\n{}\n",
+            falco_event("Terminal shell in container"),
+            falco_event("Write below binary dir"),
+        );
+        fs::write(dir.join("host/target-001/falco.jsonl"), falco).unwrap();
+    }
+
+    #[test]
+    fn falco_checks_skipped_when_no_falco_telemetry() {
+        let dir = tempfile::tempdir().unwrap();
+        create_valid_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        assert!(
+            find_check(&report, "L1-007").is_none(),
+            "L1-007 should be absent when no Falco telemetry",
+        );
+        assert!(
+            find_check(&report, "L2-009").is_none(),
+            "L2-009 should be absent when no Falco telemetry",
+        );
+    }
+
+    #[test]
+    fn falco_file_present_passes_l1_007() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-007");
+    }
+
+    #[test]
+    fn missing_falco_file_fails_l1_007() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        fs::remove_file(dir.path().join("host/target-001/falco.jsonl")).unwrap();
+        let report = run(dir.path()).unwrap();
+        assert_fail(&report, "L1-007");
+    }
+
+    #[test]
+    fn valid_falco_json_passes_l2_009() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L2-009");
+    }
+
+    #[test]
+    fn invalid_falco_json_warns_l2_009() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        fs::write(
+            dir.path().join("host/target-001/falco.jsonl"),
+            "not json\n{\"time\":\"t\",\"rule\":\"r\",\"priority\":\"p\",\"output\":\"o\"}\n",
+        )
+        .unwrap();
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-007");
+        assert_warn(&report, "L2-009");
+    }
+
+    #[test]
+    fn falco_missing_required_field_warns_l2_009() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        // Record missing the "rule" field.
+        fs::write(
+            dir.path().join("host/target-001/falco.jsonl"),
+            r#"{"time":"2026-01-15T09:01:00Z","priority":"Notice","output":"test"}"#,
+        )
+        .unwrap();
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-007");
+        assert_warn(&report, "L2-009");
+    }
+
+    #[test]
+    fn empty_falco_file_warns_l2_009() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        fs::write(dir.path().join("host/target-001/falco.jsonl"), "").unwrap();
+        let report = run(dir.path()).unwrap();
+        assert_pass(&report, "L1-007");
+        assert_warn(&report, "L2-009");
+    }
+
+    #[test]
+    fn falco_not_routed_through_generic_telemetry_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        // Falco telemetry must not trigger L1-005 / L2-006 (generic).
+        assert!(
+            find_check(&report, "L1-005").is_none(),
+            "L1-005 must not fire for falco-only host_telemetry",
+        );
+        assert!(
+            find_check(&report, "L2-006").is_none(),
+            "L2-006 must not fire for falco-only host_telemetry",
+        );
+    }
+
+    #[test]
+    fn falco_bundle_passes_all_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        create_falco_bundle(dir.path());
+        let report = run(dir.path()).unwrap();
+        assert_eq!(
+            report.summary.failed, 0,
+            "expected no failures: {:#?}",
+            report.checks,
+        );
+        for id in [
+            "L1-001", "L1-002", "L1-003", "L1-004", "L1-007", "L2-001", "L2-002", "L2-003",
+            "L2-004", "L2-005", "L2-009", "L3-001", "L3-002", "L3-003", "L3-004", "L3-005",
+            "L3-006", "L3-007", "L3-008", "L3-009", "L3-010", "L4-001", "L4-003",
+        ] {
+            assert_pass(&report, id);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `falco` module with a privileged sidecar container (using the official `falcosecurity/falco-no-driver:0.39.2` image) that shares the PID namespace of each target container, monitors system calls via `engine.kind=modern_ebpf`, and writes JSONL output into `host/<hostname>/falco.jsonl` in the bundle.
- Extend `Host` with an opt-in `falco: bool` field in scenario YAML.
- Enable `falco: true` on `backend-001` in the `ac-2-tls` scenario so a repo-level Linux scenario exercises Falco collection end-to-end.
- Widen the telemetry tuple from `(host, path)` to `(host, kind, path)` so `meta.json` records the correct kind per collector instead of hard-coding `"sysmon"`.
- Add validator checks L1-007 (Falco JSONL file existence) and L2-009 (JSON integrity and required-field presence: `time`, `rule`, `priority`, `output`).
- Exclude Falco entries from the generic telemetry checks (L1-005 / L2-006) to avoid duplicates.
- `collect_logs()` checks whether the sidecar is still running before attempting exec. If the sidecar exited (e.g. eBPF probe failure in CI), it writes an empty `falco.jsonl` and warns, so the validator can surface L2-009 rather than aborting bundle generation.
- Empty Falco output from a running sidecar also writes the file and warns, consistent with the validator's L2-009 treatment.
- L2-009 warns on empty Falco JSONL files instead of silently passing.
- Skip pcap enrichment for executions whose command exited non-zero (e.g. curl connection refused), since failed commands may not produce matching network traffic.
- Fix `concurrent_activities_produce_valid_ground_truth` E2E test to tolerate failed commands whose `src_port` stays 0 after pcap enrichment is skipped.

Closes #27

## Not addressed

- **Falco rule customization**: Explicitly out of scope per the issue.
- **Falco alert correlation with Ground Truth**: Deferred to a future issue.

## Test plan

- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo test` passes (260 tests, including 9 new Falco-specific tests and 1 pcap enrichment skip test)
- [x] L1-007 passes when `falco.jsonl` exists, fails when missing
- [x] L2-009 passes for valid JSONL, warns on invalid JSON lines, warns on missing required fields
- [x] L2-009 warns on empty `falco.jsonl` (regression test added)
- [x] Falco telemetry entries do not trigger generic L1-005 / L2-006 checks
- [x] A bundle with Falco telemetry passes all validator checks end-to-end
- [x] Docker regression test verifies Falco sidecar flags are valid; tolerates expected eBPF probe failures in CI environments without kernel support
- [x] Pcap enrichment skips failed executions (exit_code != 0) without error
- [x] `concurrent_activities` E2E test tolerates failed commands (curl exit-code 7)
- [x] `ac-2-tls` scenario loads with `falco: true` on `backend-001` (unit test)
- [ ] Linux scenario with `falco: true` collects Falco JSONL and passes L1-L2 (requires container environment)