### PR TITLE
Migrate bollard usage to 0.20.x API (#57)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bollard"
-version = "0.18.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -114,7 +114,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror",
  "tokio",
@@ -126,13 +125,13 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.47.1-rc.27.3.1"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "serde",
+ "serde_json",
  "serde_repr",
- "serde_with",
 ]
 
 [[package]]
@@ -230,16 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
- "serde_core",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +238,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -362,12 +345,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -647,17 +624,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -761,12 +727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,12 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,26 +803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,30 +826,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "semver"
@@ -990,30 +900,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.13.1",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "time",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1123,37 +1015,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -1374,7 +1235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1387,7 +1248,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap",
  "semver",
 ]
 
@@ -1509,7 +1370,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -1540,7 +1401,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.1",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -1559,7 +1420,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
-bollard = "0.18"
+bollard = "0.20"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures-util = "0.3"

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -5,12 +5,13 @@ use std::path::Path;
 
 use anyhow::{Context, Result, bail, ensure};
 use bollard::Docker;
-use bollard::container::{
-    Config, CreateContainerOptions, NetworkingConfig, RemoveContainerOptions,
+use bollard::models::{
+    ContainerCreateBody, EndpointIpamConfig, EndpointSettings, HostConfig, Ipam, IpamConfig,
+    NetworkConnectRequest, NetworkCreateRequest, NetworkingConfig,
 };
-use bollard::image::CreateImageOptions;
-use bollard::models::{EndpointIpamConfig, EndpointSettings, HostConfig, Ipam, IpamConfig};
-use bollard::network::{ConnectNetworkOptions, CreateNetworkOptions};
+use bollard::query_parameters::{
+    CreateContainerOptions, CreateImageOptions, RemoveContainerOptions,
+};
 use futures_util::TryStreamExt;
 use ipnet::Ipv4Net;
 
@@ -226,7 +227,7 @@ impl ProvisionedEnv {
                     )
                     .await?;
                     self.docker
-                        .start_container::<String>(&id, None)
+                        .start_container(&id, None)
                         .await
                         .with_context(|| format!("failed to start container '{container_name}'"))?;
                     self.container_ids.push(id.clone());
@@ -255,7 +256,7 @@ impl ProvisionedEnv {
             let sidecar_name = format!("mf-{prefix}-{}-falco", host.name);
             let sidecar_id = create_falco_sidecar(&self.docker, &sidecar_name, target_id).await?;
             self.docker
-                .start_container::<String>(&sidecar_id, None)
+                .start_container(&sidecar_id, None)
                 .await
                 .with_context(|| format!("failed to start Falco sidecar for '{}'", host.name))?;
             self.container_ids.push(sidecar_id.clone());
@@ -283,7 +284,7 @@ impl ProvisionedEnv {
             )
             .await?;
             self.docker
-                .start_container::<String>(&capture_id, None)
+                .start_container(&capture_id, None)
                 .await
                 .context("failed to start capture container")?;
             self.container_ids.push(capture_id.clone());
@@ -342,7 +343,7 @@ impl ProvisionedEnv {
         };
         for id in &self.container_ids {
             let _ = self.docker.stop_container(id, None).await;
-            let _ = self.docker.remove_container(id, Some(opts)).await;
+            let _ = self.docker.remove_container(id, Some(opts.clone())).await;
         }
         for id in &self.network_ids {
             let _ = self.docker.remove_network(id).await;
@@ -354,8 +355,8 @@ impl ProvisionedEnv {
 async fn pull_image(docker: &Docker, image: &str) -> Result<()> {
     let (repo, tag) = image.split_once(':').unwrap_or((image, "latest"));
     let opts = CreateImageOptions {
-        from_image: repo,
-        tag,
+        from_image: Some(repo.to_owned()),
+        tag: Some(tag.to_owned()),
         ..Default::default()
     };
     docker
@@ -377,18 +378,18 @@ async fn create_network(
         String::from("com.docker.network.bridge.name"),
         bridge.to_owned(),
     )]);
-    let config = CreateNetworkOptions {
+    let config = NetworkCreateRequest {
         name: name.to_owned(),
-        driver: String::from("bridge"),
-        options,
-        ipam: Ipam {
+        driver: Some(String::from("bridge")),
+        options: Some(options),
+        ipam: Some(Ipam {
             config: Some(vec![IpamConfig {
                 subnet: Some(subnet.to_owned()),
                 gateway: Some(gateway.to_string()),
                 ..Default::default()
             }]),
             ..Default::default()
-        },
+        }),
         ..Default::default()
     };
     let response = docker
@@ -417,16 +418,16 @@ async fn create_host_container(
         },
     );
 
-    let config = Config {
+    let config = ContainerCreateBody {
         image: Some(image.to_owned()),
         cmd: Some(vec!["sleep".to_owned(), "infinity".to_owned()]),
-        networking_config: Some(NetworkingConfig::<String> {
-            endpoints_config: endpoints,
+        networking_config: Some(NetworkingConfig {
+            endpoints_config: Some(endpoints),
         }),
         ..Default::default()
     };
     let opts = CreateContainerOptions {
-        name: name.to_owned(),
+        name: Some(name.to_owned()),
         ..Default::default()
     };
     let response = docker
@@ -443,15 +444,15 @@ async fn connect_container(
     container_id: &str,
     ip: Ipv4Addr,
 ) -> Result<()> {
-    let config = ConnectNetworkOptions {
+    let config = NetworkConnectRequest {
         container: container_id.to_owned(),
-        endpoint_config: EndpointSettings {
+        endpoint_config: Some(EndpointSettings {
             ipam_config: Some(EndpointIpamConfig {
                 ipv4_address: Some(ip.to_string()),
                 ..Default::default()
             }),
             ..Default::default()
-        },
+        }),
     };
     docker
         .connect_network(network, config)
@@ -475,7 +476,7 @@ async fn create_capture_container(
         .with_context(|| format!("failed to resolve pcap dir: {}", pcap_dir.display()))?;
     let bind = format!("{}:/capture", pcap_abs.display());
 
-    let config = Config {
+    let config = ContainerCreateBody {
         image: Some(CAPTURE_IMAGE.to_owned()),
         cmd: Some(vec![
             "/bin/sh".to_owned(),
@@ -494,7 +495,7 @@ async fn create_capture_container(
         ..Default::default()
     };
     let opts = CreateContainerOptions {
-        name: name.to_owned(),
+        name: Some(name.to_owned()),
         ..Default::default()
     };
     let response = docker
@@ -513,7 +514,7 @@ async fn create_falco_sidecar(
     target_container_id: &str,
 ) -> Result<String> {
     let output_path = crate::falco::CONTAINER_OUTPUT_PATH;
-    let config = Config {
+    let config = ContainerCreateBody {
         image: Some(FALCO_IMAGE.to_owned()),
         cmd: Some(vec![
             "/usr/bin/falco".to_owned(),
@@ -536,7 +537,7 @@ async fn create_falco_sidecar(
         ..Default::default()
     };
     let opts = CreateContainerOptions {
-        name: name.to_owned(),
+        name: Some(name.to_owned()),
         ..Default::default()
     };
     let response = docker
@@ -894,8 +895,8 @@ mod tests {
             // runners), Falco exits when it cannot initialise the
             // modern_ebpf engine.  Verify the exit was caused by a
             // probe/driver issue, not by invalid configuration flags.
-            use bollard::container::LogsOptions;
-            let opts = LogsOptions::<String> {
+            use bollard::query_parameters::LogsOptions;
+            let opts = LogsOptions {
                 stdout: true,
                 stderr: true,
                 ..Default::default()
@@ -947,7 +948,7 @@ mod tests {
         }
         // Verify networks are gone.
         for id in &network_ids {
-            let result = docker.inspect_network::<String>(id, None).await;
+            let result = docker.inspect_network(id, None).await;
             assert!(result.is_err(), "network {id} still exists after teardown");
         }
     }


### PR DESCRIPTION
## Summary

Bumps `bollard` from 0.18 to 0.20 and adapts `src/infra.rs` to the new API surface:

- Relocates the option imports (`CreateContainerOptions`, `RemoveContainerOptions`, `LogsOptions`, `CreateImageOptions`) to `bollard::query_parameters`, and the network/body types (`NetworkCreateRequest`, `NetworkConnectRequest`, `NetworkingConfig`, `ContainerCreateBody`) to `bollard::models`.
- Replaces the now-private `Config` struct with the public `ContainerCreateBody` at the three `create_container` call sites, and replaces `CreateNetworkOptions` / `ConnectNetworkOptions` with `NetworkCreateRequest` / `NetworkConnectRequest`.
- Wraps option/body fields that became `Option<T>` (name, driver, options, ipam, endpoint_config, from_image, tag, endpoints_config) in `Some(...)`.
- Drops the obsolete turbofish on `start_container::<String>` (3 sites in `infra.rs`) and `inspect_network::<String>` (1 test site).
- `RemoveContainerOptions` is no longer `Copy`, so the teardown loop clones it per container.

`src/activity.rs` and `src/falco.rs` compile against 0.20.2 unchanged.

This supersedes the dependabot-only PR #47, which fails CI for these reasons.

Closes #57

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (260 passed, 16 Docker-gated tests ignored)
- [x] Docker E2E tests (the `#[ignore]`d suites in `infra`, `activity`, and top-level `tests`) exercised manually against a real Docker daemon to confirm no regression — all 16 ignored tests passed locally against Docker 29.4.1
- [x] Close superseded PR #47 once this lands