### PR TITLE
Build real-to-logical timestamp mapping and rewrite GT/meta (#63)

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -9,11 +9,15 @@ use futures_util::StreamExt;
 use tokio::task::JoinSet;
 
 use crate::scenario::{Activities, Host, Phase, Protocol, parse_duration};
+use crate::time::{TimeMap, logical_offset_to_real};
 use crate::vm::{self, ProvisionedVm};
 
 /// Seconds to wait after the last activity so trailing packets reach
 /// the tcpdump capture containers.
-const CAPTURE_DRAIN_SECS: u64 = 1;
+///
+/// Exposed at crate scope so the per-execution anchor builder in
+/// [`crate::time`] uses the same drain padding as the post-run sleep.
+pub(crate) const CAPTURE_DRAIN_SECS: u64 = 1;
 
 /// Result of executing a single activity inside a container.
 pub(crate) struct Execution {
@@ -138,9 +142,12 @@ pub(crate) async fn run(
     host_containers: &[(String, String)],
     host_ips: &[(String, Vec<Ipv4Addr>)],
     activities: &Activities,
-    generation_start: DateTime<Utc>,
+    time_map: &TimeMap,
     vms: &[ProvisionedVm],
 ) -> Result<Vec<Execution>> {
+    let generation_start = time_map.real_generation_start();
+    let logical_us = time_map.logical_us();
+    let real_us = time_map.real_us();
     // Install tools only in Docker-based activity sources.
     let sources = activity_sources(activities);
     let source_containers: Vec<_> = host_containers
@@ -168,7 +175,10 @@ pub(crate) async fn run(
     // Spawn each activity as an independent task.
     let mut tasks = JoinSet::new();
     for (activity, src_ip, dst_ip, command, backend) in prepared {
-        let target_time = generation_start + activity.offset;
+        let real_offset = logical_offset_to_real(activity.offset, logical_us, real_us)?;
+        let target_time = generation_start
+            .checked_add_signed(real_offset)
+            .context("scheduled target time overflows DateTime range")?;
         let source = activity.source.to_owned();
         let target = activity.target.to_owned();
         let protocol = activity.protocol;
@@ -718,6 +728,13 @@ mod tests {
 
     use crate::test_util::{isolate_subnets, load_ac0, load_mixed_distro};
 
+    /// Builds an identity (no-compression) `TimeMap` rooted at `start`
+    /// with a 5-minute scenario duration, matching the AC-0 fixture.
+    fn identity_time_map(start: DateTime<Utc>) -> TimeMap {
+        let dur = chrono::Duration::try_minutes(5).unwrap();
+        TimeMap::new(start, start, dur, dur).unwrap()
+    }
+
     /// Provisions ac-0 containers, runs both activities immediately
     /// (using a past start time to skip offset waits), and verifies
     /// the execution results.
@@ -743,7 +760,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -837,7 +854,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -847,7 +864,11 @@ mod tests {
         env.stop_collectors().await.unwrap();
 
         crate::pcap::enrich_src_ports(&net_dir, &mut results).unwrap();
-        crate::ground_truth::write(dir.path(), &results).unwrap();
+        {
+            let tm = identity_time_map(past_start);
+            let (anchors, _) = crate::time::build_anchors(&results, &tm).unwrap();
+            crate::ground_truth::write(dir.path(), &results, &tm, &anchors).unwrap();
+        }
 
         let seg = &scenario.infrastructure.network.segments[0];
         let (_, expected_ips) = crate::infra::assign_ips(&seg.subnet, &seg.hosts).unwrap();
@@ -932,7 +953,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -992,7 +1013,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -1042,7 +1063,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -1146,7 +1167,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -1194,7 +1215,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            past_start,
+            &identity_time_map(past_start),
             &[],
         )
         .await
@@ -1220,7 +1241,11 @@ mod tests {
             assert_ne!(attack.src_port, 0, "attack src_port must be enriched");
         }
 
-        crate::ground_truth::write(dir.path(), &results).unwrap();
+        {
+            let tm = identity_time_map(past_start);
+            let (anchors, _) = crate::time::build_anchors(&results, &tm).unwrap();
+            crate::ground_truth::write(dir.path(), &results, &tm, &anchors).unwrap();
+        }
 
         let content = std::fs::read_to_string(gt_dir.join("manifest.jsonl")).unwrap();
         let records: Vec<serde_json::Value> = content
@@ -1286,7 +1311,7 @@ mod tests {
             &env.host_containers,
             &env.host_ips,
             &scenario.activities,
-            start,
+            &identity_time_map(start),
             &[],
         )
         .await

--- a/src/ground_truth.rs
+++ b/src/ground_truth.rs
@@ -2,11 +2,13 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 use crate::activity::Execution;
 use crate::scenario::{Phase, Protocol};
+use crate::time::{ExecAnchor, TimeMap};
 
 /// A single ground-truth record in the v1 JSONL format.
 #[derive(Serialize)]
@@ -38,14 +40,30 @@ struct Record {
 }
 
 /// Writes ground-truth records to `ground_truth/manifest.jsonl` inside
-/// the output directory, one JSON object per line sorted by start time.
-pub(crate) fn write(output_dir: &Path, executions: &[Execution]) -> Result<()> {
+/// the output directory, one JSON object per line in input order.
+///
+/// Per-execution `start`/`end` timestamps are rewritten through the
+/// matching anchor (so each execution's internal duration is preserved
+/// exactly under compression); records with no matching anchor fall
+/// back to the global `TimeMap`. Returns the maximum rewritten
+/// timestamp seen (or `None` when no records are written), feeding the
+/// `meta.json` aggregator.
+pub(crate) fn write(
+    output_dir: &Path,
+    executions: &[Execution],
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+) -> Result<Option<DateTime<Utc>>> {
     let path = output_dir.join("ground_truth").join("manifest.jsonl");
     let file =
         File::create(&path).with_context(|| format!("failed to create {}", path.display()))?;
     let mut writer = BufWriter::new(file);
+    let mut max_ts: Option<DateTime<Utc>> = None;
 
     for exec in executions {
+        let (logical_start, logical_end) = rewrite_execution(exec, time_map, anchors)?;
+        observe(&mut max_ts, logical_end);
+
         let (label, category, technique, phase, tool, campaign_id, step) = match &exec.attack {
             None => ("normal", None, None, None, None, None, None),
             Some(detail) => (
@@ -62,8 +80,8 @@ pub(crate) fn write(output_dir: &Path, executions: &[Execution]) -> Result<()> {
         let record = Record {
             scope: "session",
             label,
-            start: format_ts(exec.start),
-            end: format_ts(exec.end),
+            start: format_ts(logical_start),
+            end: format_ts(logical_end),
             source: exec.source.clone(),
             target: exec.target.clone(),
             session_type: "network",
@@ -88,7 +106,41 @@ pub(crate) fn write(output_dir: &Path, executions: &[Execution]) -> Result<()> {
     writer
         .flush()
         .context("failed to flush ground truth file")?;
-    Ok(())
+    Ok(max_ts)
+}
+
+fn observe(max_ts: &mut Option<DateTime<Utc>>, ts: DateTime<Utc>) {
+    if max_ts.is_none_or(|m| ts > m) {
+        *max_ts = Some(ts);
+    }
+}
+
+/// Rewrites an `Execution`'s `start`/`end` to logical time. Prefers
+/// the matching per-execution anchor (which preserves intra-session
+/// timing exactly); falls back to the global `TimeMap` if no anchor
+/// matches.
+fn rewrite_execution(
+    exec: &Execution,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+) -> Result<(DateTime<Utc>, DateTime<Utc>)> {
+    let anchor = anchors
+        .iter()
+        .find(|a| a.real_start == exec.start && a.source == exec.source && a.target == exec.target);
+    match anchor {
+        Some(a) => {
+            let logical_start = a.logical_start;
+            let logical_end = a
+                .logical_start
+                .checked_add_signed(exec.end - a.real_start)
+                .ok_or_else(|| anyhow!("anchor-based rewrite end overflows DateTime range"))?;
+            Ok((logical_start, logical_end))
+        }
+        None => Ok((
+            time_map.to_logical(exec.start)?,
+            time_map.to_logical(exec.end)?,
+        )),
+    }
 }
 
 /// Formats a `DateTime<Utc>` as an ISO 8601 string without sub-second
@@ -101,10 +153,17 @@ fn format_ts(dt: chrono::DateTime<chrono::Utc>) -> String {
 mod tests {
     use std::net::Ipv4Addr;
 
-    use chrono::TimeZone;
+    use chrono::{Duration, TimeZone};
 
     use super::*;
     use crate::activity::AttackDetail;
+    use crate::time::build_anchors;
+
+    fn identity_time_map() -> TimeMap {
+        let t = chrono::Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let dur = chrono::Duration::try_minutes(5).unwrap();
+        TimeMap::new(t, t, dur, dur).unwrap()
+    }
 
     fn normal_execution() -> Execution {
         Execution {
@@ -149,7 +208,8 @@ mod tests {
     fn write_and_read(executions: &[Execution]) -> String {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("ground_truth")).unwrap();
-        write(dir.path(), executions).unwrap();
+        let tm = identity_time_map();
+        write(dir.path(), executions, &tm, &[]).unwrap();
         std::fs::read_to_string(dir.path().join("ground_truth/manifest.jsonl")).unwrap()
     }
 
@@ -493,5 +553,64 @@ mod tests {
                 "phase {phase:?} should serialize as '{expected}'",
             );
         }
+    }
+
+    // ── compression rewrite ────────────────────────────────────
+
+    /// Under compression, a record's `start` is rewritten to its
+    /// anchor's `logical_start` (shifted onto the logical timeline)
+    /// while the second-precision `end - start` reflects the
+    /// execution's real duration. Asserted at second resolution
+    /// because [`format_ts`] truncates sub-seconds.
+    #[test]
+    fn compression_rewrites_gt_start_and_preserves_intra_session_duration() {
+        let real_start = chrono::Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = chrono::Utc.with_ymd_and_hms(2026, 5, 3, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        // Execution begins 60 real seconds in, lasts 2 real seconds.
+        let exec_start = real_start + Duration::try_seconds(60).unwrap();
+        let exec_end = exec_start + Duration::try_seconds(2).unwrap();
+        let exec = Execution {
+            start: exec_start,
+            end: exec_end,
+            ..normal_execution()
+        };
+        let (anchors, _) = build_anchors(&[exec], &tm).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("ground_truth")).unwrap();
+        let exec_for_write = Execution {
+            start: exec_start,
+            end: exec_end,
+            ..normal_execution()
+        };
+        let max_ts = write(dir.path(), &[exec_for_write], &tm, &anchors)
+            .unwrap()
+            .expect("at least one record");
+        let content =
+            std::fs::read_to_string(dir.path().join("ground_truth/manifest.jsonl")).unwrap();
+        let record: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+
+        // Intra-session duration is preserved exactly: end - start = 2s.
+        let written_start =
+            chrono::DateTime::parse_from_rfc3339(record["start"].as_str().unwrap()).unwrap();
+        let written_end =
+            chrono::DateTime::parse_from_rfc3339(record["end"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            written_end - written_start,
+            Duration::try_seconds(2).unwrap()
+        );
+
+        // The aggregator's max equals the rewritten end timestamp.
+        assert_eq!(
+            max_ts,
+            anchors[0].logical_start + Duration::try_seconds(2).unwrap(),
+        );
     }
 }

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hasher;
 use std::net::Ipv4Addr;
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::{Context, Result, bail, ensure};
 use bollard::Docker;
@@ -88,6 +89,12 @@ fn bridge_name(prefix: &str, segment: &str) -> String {
     format!("mf-{:011x}", hasher.finish() & 0xFFF_FFFF_FFFF)
 }
 
+/// Process-global counter mixed into [`generate_run_id`] so that two
+/// concurrent calls within the same test binary always produce
+/// distinct run IDs, even when `SystemTime::now()` returns the same
+/// nanosecond bucket on coarse clocks.
+static RUN_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
+
 /// Generates a short, per-run identifier to avoid Docker name collisions
 /// across concurrent runs of the same scenario.
 fn generate_run_id() -> String {
@@ -98,6 +105,11 @@ fn generate_run_id() -> String {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     h.write_u128(nanos);
     h.write_u32(std::process::id());
+    // Atomic counter guarantees in-process uniqueness even if two
+    // calls land in the same nanosecond on a coarse clock. Without
+    // this, parallel `#[ignore]` Docker E2E tests occasionally hit a
+    // 409 "network already exists" when their run IDs collide.
+    h.write_u32(RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
     // Intentionally truncate: we only need 32 bits of entropy for
     // a short collision-resistant suffix, not a full 64-bit hash.
     #[allow(clippy::cast_possible_truncation)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 
 mod activity;
@@ -16,6 +16,7 @@ mod scenario;
 mod sysmon;
 #[cfg(test)]
 mod test_util;
+mod time;
 mod validator;
 mod vm;
 
@@ -86,7 +87,8 @@ async fn generate(scenario_path: &str, output: &str) -> Result<()> {
         scenario.activities.attack.len(),
     );
 
-    let start = Utc::now();
+    let real_generation_start = Utc::now();
+    let time_map = build_time_map(&scenario, real_generation_start)?;
     let output_dir = Path::new(output);
     create_output_dirs(output_dir, &scenario)?;
 
@@ -101,7 +103,8 @@ async fn generate(scenario_path: &str, output: &str) -> Result<()> {
     );
 
     // Run setup, activities, then assemble the bundle; always tear down.
-    let result = setup_run_and_assemble(&env, &scenario, scenario_path, output_dir, start).await;
+    let result =
+        setup_run_and_assemble(&env, &scenario, scenario_path, output_dir, &time_map).await;
 
     let teardown_result = env.down().await;
     result?;
@@ -111,6 +114,31 @@ async fn generate(scenario_path: &str, output: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolves the effective `start_at` and `logical_duration` from the
+/// scenario and builds the run's `TimeMap`. When `start_at` is absent
+/// the logical timeline is anchored to `real_generation_start`; when
+/// `logical_duration` is absent it equals `scenario.duration`
+/// (identity scale).
+fn build_time_map(
+    scenario: &scenario::Scenario,
+    real_generation_start: DateTime<Utc>,
+) -> Result<time::TimeMap> {
+    let scenario_duration = scenario::parse_duration(&scenario.duration)
+        .with_context(|| format!("invalid scenario duration '{}'", scenario.duration))?;
+    let logical_duration = match &scenario.logical_duration {
+        Some(s) => scenario::parse_duration(s)
+            .with_context(|| format!("invalid logical_duration '{s}'"))?,
+        None => scenario_duration,
+    };
+    let start_at = scenario.start_at.unwrap_or(real_generation_start);
+    time::TimeMap::new(
+        start_at,
+        real_generation_start,
+        scenario_duration,
+        logical_duration,
+    )
+}
+
 /// Runs setup commands, executes activities, stops collectors, and
 /// assembles the output bundle.
 async fn setup_run_and_assemble(
@@ -118,7 +146,7 @@ async fn setup_run_and_assemble(
     scenario: &scenario::Scenario,
     scenario_path: &str,
     output_dir: &Path,
-    start: chrono::DateTime<chrono::Utc>,
+    time_map: &time::TimeMap,
 ) -> Result<()> {
     // Install Sysmon on VMs that have it enabled.
     for vm_host in &env.vms {
@@ -141,7 +169,7 @@ async fn setup_run_and_assemble(
         &env.host_containers,
         &env.host_ips,
         &scenario.activities,
-        start,
+        time_map,
         &env.vms,
     )
     .await?;
@@ -194,7 +222,7 @@ async fn setup_run_and_assemble(
         scenario_path,
         scenario,
         &env.host_ips,
-        start,
+        time_map,
         &mut executions,
         &telemetry,
     )
@@ -202,15 +230,17 @@ async fn setup_run_and_assemble(
 
 /// Assembles the dataset bundle from collected artifacts.
 ///
-/// Reads pcap captures to enrich execution records with source ports,
-/// then writes `ground_truth/manifest.jsonl` and `meta.json` into
-/// the output directory.
+/// Reads pcap captures to enrich execution records with source ports
+/// (still matched on *real* timestamps), builds per-execution anchors,
+/// rewrites Ground Truth onto the logical timeline, and finally writes
+/// `meta.json` with the aggregated `actual_end` returned by each
+/// rewrite pass.
 fn assemble_bundle(
     output_dir: &Path,
     scenario_path: &str,
     scenario: &scenario::Scenario,
     host_ips: &[(String, Vec<std::net::Ipv4Addr>)],
-    start: chrono::DateTime<chrono::Utc>,
+    time_map: &time::TimeMap,
     executions: &mut [activity::Execution],
     telemetry: &[(String, String, String)],
 ) -> Result<()> {
@@ -218,7 +248,34 @@ fn assemble_bundle(
     pcap::enrich_src_ports(&net_dir, executions)?;
     println!("Enriched source ports from pcap");
 
-    ground_truth::write(output_dir, executions)?;
+    let (anchors, warnings) = time::build_anchors(executions, time_map)?;
+    for w in &warnings {
+        eprintln!(
+            "warning: executions {}→{} and {}→{} have overlapping real windows; \
+             packets in the overlap go to the latter",
+            w.a_source, w.a_target, w.b_source, w.b_target,
+        );
+    }
+
+    // Seed the aggregator from each anchor's projected logical end
+    // (logical_start + intra-window duration). The GT pass then
+    // observes its own max as the aggregator climbs.
+    let mut actual_end = time_map.start_at();
+    for a in &anchors {
+        let logical_end = a
+            .logical_start
+            .checked_add_signed(a.real_end - a.real_start)
+            .context("anchor projected logical end overflows DateTime range")?;
+        if logical_end > actual_end {
+            actual_end = logical_end;
+        }
+    }
+
+    if let Some(max_ts) = ground_truth::write(output_dir, executions, time_map, &anchors)?
+        && max_ts > actual_end
+    {
+        actual_end = max_ts;
+    }
     println!("Wrote ground_truth/manifest.jsonl");
 
     let scenario_filename = Path::new(scenario_path).file_name().map_or_else(
@@ -230,7 +287,8 @@ fn assemble_bundle(
         &scenario_filename,
         scenario,
         host_ips,
-        start,
+        time_map,
+        actual_end,
         telemetry,
     )?;
     println!("Wrote meta.json");
@@ -320,6 +378,11 @@ mod tests {
         ]
     }
 
+    fn test_time_map(start: DateTime<Utc>, scenario: &scenario::Scenario) -> time::TimeMap {
+        let dur = scenario::parse_duration(&scenario.duration).unwrap();
+        time::TimeMap::new(start, start, dur, dur).unwrap()
+    }
+
     fn make_execution(ts: i64, attack: Option<activity::AttackDetail>) -> activity::Execution {
         let start = chrono::TimeZone::timestamp_opt(&chrono::Utc, ts, 0).unwrap();
         activity::Execution {
@@ -355,12 +418,13 @@ mod tests {
         let start = chrono::TimeZone::timestamp_opt(&chrono::Utc, ts, 0).unwrap();
         let mut executions = vec![make_execution(ts, None)];
 
+        let time_map = test_time_map(start, &scenario);
         assemble_bundle(
             dir.path(),
             "ac-0.scenario.yaml",
             &scenario,
             &host_ips,
-            start,
+            &time_map,
             &mut executions,
             &[],
         )
@@ -409,12 +473,13 @@ mod tests {
             }),
         )];
 
+        let time_map = test_time_map(start, &scenario);
         assemble_bundle(
             dir.path(),
             "ac-0.scenario.yaml",
             &scenario,
             &host_ips,
-            start,
+            &time_map,
             &mut executions,
             &[],
         )
@@ -463,12 +528,13 @@ mod tests {
             ),
         ];
 
+        let time_map = test_time_map(start, &scenario);
         assemble_bundle(
             dir.path(),
             "ac-0.scenario.yaml",
             &scenario,
             &host_ips,
-            start,
+            &time_map,
             &mut executions,
             &[],
         )
@@ -501,6 +567,67 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(dir.path().join("meta.json")).unwrap())
                 .unwrap();
         assert_eq!(meta["hosts"].as_array().unwrap().len(), 2);
+    }
+
+    /// Under compression, enrichment still matches on real timestamps
+    /// while GT and meta land on the logical timeline.
+    #[test]
+    fn assemble_bundle_under_compression_enriches_and_rewrites() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        create_output_dirs(dir.path(), &scenario).unwrap();
+
+        let ts: i64 = 1_737_000_030;
+        write_synthetic_pcap(
+            &dir.path().join("net"),
+            "lan.pcap",
+            &[(u32::try_from(ts).unwrap(), 49152)],
+        );
+
+        let host_ips = ac0_host_ips();
+        let real_start = chrono::TimeZone::timestamp_opt(&chrono::Utc, ts, 0).unwrap();
+        let logical_start = chrono::DateTime::parse_from_rfc3339("2026-05-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // 5 real minutes → 14 logical days.
+        let time_map = time::TimeMap::new(
+            logical_start,
+            real_start,
+            chrono::Duration::try_minutes(5).unwrap(),
+            chrono::Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let mut executions = vec![make_execution(ts, None)];
+
+        assemble_bundle(
+            dir.path(),
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &time_map,
+            &mut executions,
+            &[],
+        )
+        .unwrap();
+
+        // Enrichment matched on real timestamps and ran before rewrite.
+        assert_eq!(executions[0].src_port, 49152);
+
+        // GT start is logical_start (execution begins exactly at the
+        // real_generation_start, so the anchor's logical_start equals
+        // the effective start_at).
+        let gt = fs::read_to_string(dir.path().join("ground_truth/manifest.jsonl")).unwrap();
+        let record: serde_json::Value = serde_json::from_str(gt.trim()).unwrap();
+        assert_eq!(record["start"], "2026-05-03T00:00:00Z");
+
+        // meta.json reflects the logical timeline.
+        let meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join("meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta["duration"]["actual_start"], "2026-05-03T00:00:00Z");
+        // generated_at is the real wall-clock at run start, not logical.
+        let expected_generated_at = real_start.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        assert_eq!(meta["generated_at"], expected_generated_at);
     }
 
     // ── create_output_dirs ───────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,21 +257,39 @@ fn assemble_bundle(
         );
     }
 
-    // Seed the aggregator from each anchor's projected logical end
-    // (logical_start + intra-window duration). The GT pass then
-    // observes its own max as the aggregator climbs.
-    let mut actual_end = time_map.start_at();
-    for a in &anchors {
-        let logical_end = a
-            .logical_start
-            .checked_add_signed(a.real_end - a.real_start)
-            .context("anchor projected logical end overflows DateTime range")?;
-        if logical_end > actual_end {
-            actual_end = logical_end;
+    // Identity case (the TimeMap is a 1:1 pass-through, i.e. neither
+    // `start_at` nor `logical_duration` is set): fall back to the
+    // pre-#63 `actual_end = start + scenario.duration` so live runs
+    // without any time rewriting retain their previous meta semantics.
+    // The GT rewrite still runs (it is a no-op under the identity
+    // TimeMap), and overlap/drain handling is unaffected.
+    let identity_run = time_map.is_identity();
+    let mut actual_end = if identity_run {
+        let dur = scenario::parse_duration(&scenario.duration)
+            .with_context(|| format!("invalid scenario duration '{}'", scenario.duration))?;
+        time_map
+            .start_at()
+            .checked_add_signed(dur)
+            .context("identity-case actual_end overflows DateTime range")?
+    } else {
+        // Seed the aggregator from each anchor's projected logical end
+        // (logical_start + intra-window duration). The GT pass then
+        // observes its own max as the aggregator climbs.
+        let mut seed = time_map.start_at();
+        for a in &anchors {
+            let logical_end = a
+                .logical_start
+                .checked_add_signed(a.real_end - a.real_start)
+                .context("anchor projected logical end overflows DateTime range")?;
+            if logical_end > seed {
+                seed = logical_end;
+            }
         }
-    }
+        seed
+    };
 
     if let Some(max_ts) = ground_truth::write(output_dir, executions, time_map, &anchors)?
+        && !identity_run
         && max_ts > actual_end
     {
         actual_end = max_ts;
@@ -567,6 +585,55 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(dir.path().join("meta.json")).unwrap())
                 .unwrap();
         assert_eq!(meta["hosts"].as_array().unwrap().len(), 2);
+    }
+
+    /// Identity-case parity: with neither `start_at` nor
+    /// `logical_duration` set, `meta.duration.actual_end` must equal
+    /// `start + scenario.duration` (the pre-#63 fallback), independent
+    /// of the executions' actual end timestamps.
+    #[test]
+    fn assemble_bundle_identity_uses_legacy_actual_end() {
+        let scenario = load_ac0();
+        let dir = tempfile::tempdir().unwrap();
+        create_output_dirs(dir.path(), &scenario).unwrap();
+
+        let ts: i64 = 1_737_000_030;
+        write_synthetic_pcap(
+            &dir.path().join("net"),
+            "lan.pcap",
+            &[(u32::try_from(ts).unwrap(), 49152)],
+        );
+
+        let host_ips = ac0_host_ips();
+        let start = chrono::TimeZone::timestamp_opt(&chrono::Utc, ts, 0).unwrap();
+        // Single ~1s execution well short of the scenario's declared 5m
+        // duration. If we incorrectly aggregated GT/anchor timestamps,
+        // actual_end would land ~2s past `start`, not at `start + 5m`.
+        let mut executions = vec![make_execution(ts, None)];
+
+        let time_map = test_time_map(start, &scenario);
+        assert!(time_map.is_identity());
+        assemble_bundle(
+            dir.path(),
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &time_map,
+            &mut executions,
+            &[],
+        )
+        .unwrap();
+
+        let meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join("meta.json")).unwrap())
+                .unwrap();
+        let dur = scenario::parse_duration(&scenario.duration).unwrap();
+        let expected_end = (start + dur).format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        assert_eq!(meta["duration"]["actual_end"], expected_end);
+        assert_eq!(
+            meta["duration"]["actual_start"],
+            start.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        );
     }
 
     /// Under compression, enrichment still matches on real timestamps

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -7,21 +7,34 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 use crate::scenario::{
-    self, Attacker, Encryption, Os, Role, Scale, Scenario, Threat, VantagePoint, Workload,
+    Attacker, Encryption, Os, Role, Scale, Scenario, Threat, VantagePoint, Workload,
 };
+use crate::time::TimeMap;
 
 const SCHEMA_VERSION: &str = "1";
 
 /// Writes `meta.json` into the output directory.
+///
+/// `actual_end` is the maximum rewritten timestamp aggregated by the
+/// caller across every artifact rewrite pass; this function does not
+/// recompute it from the scenario duration.
 pub(crate) fn write(
     output_dir: &Path,
     scenario_filename: &str,
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
-    start: DateTime<Utc>,
+    time_map: &TimeMap,
+    actual_end: DateTime<Utc>,
     telemetry: &[(String, String, String)],
 ) -> Result<()> {
-    let meta = build(scenario_filename, scenario, host_ips, start, telemetry)?;
+    let meta = build(
+        scenario_filename,
+        scenario,
+        host_ips,
+        time_map,
+        actual_end,
+        telemetry,
+    )?;
     let json = serde_json::to_string_pretty(&meta).context("failed to serialise meta.json")?;
     let path = output_dir.join("meta.json");
     fs::write(&path, json).with_context(|| format!("failed to write {}", path.display()))?;
@@ -32,11 +45,14 @@ fn build(
     scenario_filename: &str,
     scenario: &Scenario,
     host_ips: &[(String, Vec<Ipv4Addr>)],
-    start: DateTime<Utc>,
+    time_map: &TimeMap,
+    actual_end: DateTime<Utc>,
     telemetry: &[(String, String, String)],
 ) -> Result<BundleMeta> {
-    let total_duration = scenario::parse_duration(&scenario.duration)?;
-    let end = start + total_duration;
+    let total = scenario
+        .logical_duration
+        .clone()
+        .unwrap_or_else(|| scenario.duration.clone());
 
     let hosts: Vec<MetaHost> = host_ips
         .iter()
@@ -82,11 +98,11 @@ fn build(
         schema_version: SCHEMA_VERSION.to_owned(),
         scenario: scenario_filename.to_owned(),
         scenario_version: scenario.version.clone(),
-        generated_at: fmt_time(start),
+        generated_at: fmt_time(time_map.real_generation_start()),
         duration: MetaDuration {
-            total: scenario.duration.clone(),
-            actual_start: fmt_time(start),
-            actual_end: fmt_time(end),
+            total,
+            actual_start: fmt_time(time_map.start_at()),
+            actual_end: fmt_time(actual_end),
         },
         environment: MetaEnvironment {
             scale: scenario.environment.scale,
@@ -190,9 +206,19 @@ struct MetaTelemetryEntry {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Duration;
+
     use super::*;
+    use crate::scenario::parse_duration;
 
     type HostIps = Vec<(String, Vec<Ipv4Addr>)>;
+
+    /// Builds an identity (no-compression) `TimeMap` rooted at the
+    /// given timestamp, sized to the scenario's declared duration.
+    fn identity_time_map(start: DateTime<Utc>, scenario: &Scenario) -> TimeMap {
+        let dur = parse_duration(&scenario.duration).unwrap();
+        TimeMap::new(start, start, dur, dur).unwrap()
+    }
 
     fn ac0_test_inputs() -> (Scenario, HostIps, DateTime<Utc>) {
         let yaml = include_str!("../scenarios/ac-0.scenario.yaml");
@@ -210,10 +236,24 @@ mod tests {
         (scenario, host_ips, start)
     }
 
+    fn ac0_build(scenario: &Scenario, host_ips: &HostIps, start: DateTime<Utc>) -> BundleMeta {
+        let tm = identity_time_map(start, scenario);
+        let actual_end = start + Duration::try_minutes(5).unwrap();
+        build(
+            "ac-0.scenario.yaml",
+            scenario,
+            host_ips,
+            &tm,
+            actual_end,
+            &[],
+        )
+        .unwrap()
+    }
+
     #[test]
     fn build_meta_matches_expected_structure() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac0_build(&scenario, &host_ips, start);
 
         assert_eq!(meta.schema_version, "1");
         assert_eq!(meta.scenario, "ac-0.scenario.yaml");
@@ -237,7 +277,7 @@ mod tests {
     #[test]
     fn build_meta_json_roundtrip() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac0_build(&scenario, &host_ips, start);
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -251,7 +291,7 @@ mod tests {
     #[test]
     fn build_meta_matches_ac0_reference() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac0_build(&scenario, &host_ips, start);
         let actual: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&meta).unwrap()).unwrap();
 
@@ -265,12 +305,15 @@ mod tests {
     fn write_creates_valid_json_file() {
         let (scenario, host_ips, start) = ac0_test_inputs();
         let dir = tempfile::tempdir().unwrap();
+        let tm = identity_time_map(start, &scenario);
+        let actual_end = start + Duration::try_minutes(5).unwrap();
         write(
             dir.path(),
             "ac-0.scenario.yaml",
             &scenario,
             &host_ips,
-            start,
+            &tm,
+            actual_end,
             &[],
         )
         .unwrap();
@@ -288,8 +331,18 @@ mod tests {
     fn build_meta_rejects_unknown_host() {
         let (scenario, _, start) = ac0_test_inputs();
         let host_ips = vec![("ghost-host".to_owned(), vec![Ipv4Addr::new(10, 100, 0, 99)])];
+        let tm = identity_time_map(start, &scenario);
+        let actual_end = start + Duration::try_minutes(5).unwrap();
 
-        let err = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap_err();
+        let err = build(
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            actual_end,
+            &[],
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("not found in scenario"),
             "unexpected error: {err}",
@@ -299,7 +352,7 @@ mod tests {
     #[test]
     fn build_meta_omits_vantage_point_when_absent() {
         let (scenario, host_ips, start) = ac0_test_inputs();
-        let meta = build("ac-0.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac0_build(&scenario, &host_ips, start);
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -329,10 +382,24 @@ mod tests {
         (scenario, host_ips, start)
     }
 
+    fn ac2_build(scenario: &Scenario, host_ips: &HostIps, start: DateTime<Utc>) -> BundleMeta {
+        let tm = identity_time_map(start, scenario);
+        let total = parse_duration(&scenario.duration).unwrap();
+        build(
+            "ac-2-tls.scenario.yaml",
+            scenario,
+            host_ips,
+            &tm,
+            start + total,
+            &[],
+        )
+        .unwrap()
+    }
+
     #[test]
     fn build_meta_includes_vantage_points() {
         let (scenario, host_ips, start) = ac2_tls_test_inputs();
-        let meta = build("ac-2-tls.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac2_build(&scenario, &host_ips, start);
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -351,7 +418,7 @@ mod tests {
     #[test]
     fn build_meta_tls_has_correct_encryption() {
         let (scenario, host_ips, start) = ac2_tls_test_inputs();
-        let meta = build("ac-2-tls.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac2_build(&scenario, &host_ips, start);
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -361,7 +428,7 @@ mod tests {
     #[test]
     fn build_meta_tls_segments_have_subnets() {
         let (scenario, host_ips, start) = ac2_tls_test_inputs();
-        let meta = build("ac-2-tls.scenario.yaml", &scenario, &host_ips, start, &[]).unwrap();
+        let meta = ac2_build(&scenario, &host_ips, start);
         let json = serde_json::to_string_pretty(&meta).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -371,5 +438,53 @@ mod tests {
         assert_eq!(segments[0]["subnet"], "10.200.0.0/24");
         assert_eq!(segments[1]["name"], "inner");
         assert_eq!(segments[1]["subnet"], "10.200.1.0/24");
+    }
+
+    #[test]
+    fn build_meta_uses_logical_duration_when_present() {
+        let (mut scenario, host_ips, start) = ac0_test_inputs();
+        scenario.logical_duration = Some("14d".to_owned());
+        let logical_start = DateTime::parse_from_rfc3339("2026-05-03T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let tm = TimeMap::new(
+            logical_start,
+            start,
+            parse_duration(&scenario.duration).unwrap(),
+            parse_duration("14d").unwrap(),
+        )
+        .unwrap();
+        let actual_end = logical_start + Duration::try_days(14).unwrap();
+        let meta = build(
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            actual_end,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(meta.generated_at, "2026-01-15T09:00:00Z");
+        assert_eq!(meta.duration.total, "14d");
+        assert_eq!(meta.duration.actual_start, "2026-05-03T00:00:00Z");
+        assert_eq!(meta.duration.actual_end, "2026-05-17T00:00:00Z");
+    }
+
+    #[test]
+    fn build_meta_empty_actual_end_equals_actual_start() {
+        // When the aggregator never observes a rewritten timestamp,
+        // callers seed it with `actual_start` and pass it back here.
+        let (scenario, host_ips, start) = ac0_test_inputs();
+        let tm = identity_time_map(start, &scenario);
+        let meta = build(
+            "ac-0.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            tm.start_at(),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(meta.duration.actual_end, meta.duration.actual_start);
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -60,6 +60,14 @@ impl TimeMap {
         self.real_generation_start
     }
 
+    /// Returns `true` when the map is a true pass-through: the logical
+    /// timeline coincides with the real one and scale is 1:1. Used by
+    /// the bundle assembler to preserve pre-#63 `actual_end` semantics
+    /// when neither `start_at` nor `logical_duration` is set.
+    pub(crate) fn is_identity(&self) -> bool {
+        self.start_at == self.real_generation_start && self.logical_us == self.real_us
+    }
+
     pub(crate) fn logical_us(&self) -> i64 {
         self.logical_us
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,589 @@
+//! Real-to-logical timestamp mapping and per-execution anchors.
+//!
+//! The affine mapping is:
+//!
+//! ```text
+//! logical_ts = start_at + (real_ts - real_generation_start) * scale
+//! scale      = logical_duration / scenario.duration
+//! ```
+//!
+//! All arithmetic uses microsecond integers with an `i128` intermediate
+//! product so realistic compression ratios (e.g., `2w → 30m`) cannot
+//! overflow `i64` during the multiply. Final narrowing back to `i64` is
+//! surfaced as an error via [`i64::try_from`].
+
+use anyhow::{Context, Result, anyhow, ensure};
+use chrono::{DateTime, Duration, Utc};
+
+use crate::activity::{CAPTURE_DRAIN_SECS, Execution};
+
+/// Affine mapping from real wall-clock time to the scenario's declared
+/// logical timeline. Built once per run before activities execute.
+pub(crate) struct TimeMap {
+    start_at: DateTime<Utc>,
+    real_generation_start: DateTime<Utc>,
+    logical_us: i64,
+    real_us: i64,
+}
+
+impl TimeMap {
+    /// Builds a [`TimeMap`] from the effective `start_at`, the run's
+    /// `real_generation_start`, and the scenario's real and logical
+    /// durations.
+    pub(crate) fn new(
+        start_at: DateTime<Utc>,
+        real_generation_start: DateTime<Utc>,
+        scenario_duration: Duration,
+        logical_duration: Duration,
+    ) -> Result<Self> {
+        let real_us = scenario_duration
+            .num_microseconds()
+            .context("scenario duration exceeds microsecond range")?;
+        let logical_us = logical_duration
+            .num_microseconds()
+            .context("logical duration exceeds microsecond range")?;
+        ensure!(real_us > 0, "scenario duration must be strictly positive");
+        ensure!(logical_us > 0, "logical duration must be strictly positive");
+        Ok(Self {
+            start_at,
+            real_generation_start,
+            logical_us,
+            real_us,
+        })
+    }
+
+    pub(crate) fn start_at(&self) -> DateTime<Utc> {
+        self.start_at
+    }
+
+    pub(crate) fn real_generation_start(&self) -> DateTime<Utc> {
+        self.real_generation_start
+    }
+
+    pub(crate) fn logical_us(&self) -> i64 {
+        self.logical_us
+    }
+
+    pub(crate) fn real_us(&self) -> i64 {
+        self.real_us
+    }
+
+    /// Maps a real wall-clock timestamp onto the logical timeline.
+    pub(crate) fn to_logical(&self, real: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        let delta_us = (real - self.real_generation_start)
+            .num_microseconds()
+            .context("real-to-generation delta exceeds microsecond range")?;
+        let scaled = i128::from(delta_us) * i128::from(self.logical_us) / i128::from(self.real_us);
+        let scaled_us = i64::try_from(scaled)
+            .map_err(|_| anyhow!("logical timestamp microseconds overflow i64"))?;
+        self.start_at
+            .checked_add_signed(Duration::microseconds(scaled_us))
+            .ok_or_else(|| anyhow!("computed logical timestamp overflows DateTime range"))
+    }
+}
+
+/// Per-execution anchor that preserves intra-session timing when the
+/// rewriter maps a record whose real timestamp falls inside the
+/// execution's window.
+pub(crate) struct ExecAnchor {
+    pub(crate) real_start: DateTime<Utc>,
+    pub(crate) real_end: DateTime<Utc>,
+    pub(crate) logical_start: DateTime<Utc>,
+    pub(crate) source: String,
+    pub(crate) target: String,
+}
+
+/// Pair of executions whose anchor windows intersect after drain
+/// clamping. Reported as data; the call site is responsible for
+/// printing the human-readable warning.
+pub(crate) struct OverlapWarning {
+    pub(crate) a_source: String,
+    pub(crate) a_target: String,
+    pub(crate) b_source: String,
+    pub(crate) b_target: String,
+}
+
+/// Builds the per-execution anchor list sorted by real-start, padding
+/// each `real_end` with [`CAPTURE_DRAIN_SECS`] and clamping it against
+/// the next anchor whose `real_start` is strictly greater. Also
+/// returns any overlap warnings the call site can surface.
+pub(crate) fn build_anchors(
+    executions: &[Execution],
+    time_map: &TimeMap,
+) -> Result<(Vec<ExecAnchor>, Vec<OverlapWarning>)> {
+    let drain_secs =
+        i64::try_from(CAPTURE_DRAIN_SECS).context("CAPTURE_DRAIN_SECS exceeds i64 range")?;
+    let drain = Duration::try_seconds(drain_secs).context("drain duration out of range")?;
+
+    let mut sorted: Vec<&Execution> = executions.iter().collect();
+    sorted.sort_by_key(|e| e.start);
+
+    let mut anchors = Vec::with_capacity(sorted.len());
+    for (i, exec) in sorted.iter().enumerate() {
+        let padded_end = exec.end.checked_add_signed(drain).ok_or_else(|| {
+            anyhow!(
+                "drain-padded end overflows for execution {}→{}",
+                exec.source,
+                exec.target,
+            )
+        })?;
+        let next_start = sorted[i + 1..]
+            .iter()
+            .map(|e| e.start)
+            .find(|s| *s > exec.start);
+        let real_end = match next_start {
+            Some(ns) => padded_end.min(ns),
+            None => padded_end,
+        };
+        let logical_start = time_map.to_logical(exec.start)?;
+        anchors.push(ExecAnchor {
+            real_start: exec.start,
+            real_end,
+            logical_start,
+            source: exec.source.clone(),
+            target: exec.target.clone(),
+        });
+    }
+
+    let warnings = detect_overlaps(&anchors);
+    Ok((anchors, warnings))
+}
+
+/// Returns one [`OverlapWarning`] per pair of anchors whose
+/// `[real_start, real_end]` windows intersect strictly. Touching at
+/// the endpoint (`b.real_start == a.real_end`) is not an overlap.
+pub(crate) fn detect_overlaps(anchors: &[ExecAnchor]) -> Vec<OverlapWarning> {
+    let mut warnings = Vec::new();
+    for i in 0..anchors.len() {
+        for j in (i + 1)..anchors.len() {
+            let a = &anchors[i];
+            let b = &anchors[j];
+            let (earlier, later) = if a.real_start <= b.real_start {
+                (a, b)
+            } else {
+                (b, a)
+            };
+            if later.real_start < earlier.real_end {
+                warnings.push(OverlapWarning {
+                    a_source: earlier.source.clone(),
+                    a_target: earlier.target.clone(),
+                    b_source: later.source.clone(),
+                    b_target: later.target.clone(),
+                });
+            }
+        }
+    }
+    warnings
+}
+
+/// Rewrites a real timestamp onto the logical timeline. Records whose
+/// real timestamp falls inside some anchor window are rewritten via
+/// that anchor with no scaling (intra-session preservation); records
+/// outside every window fall back to the global `TimeMap`.
+//
+// Ground Truth (#63) rewrites by execution identity to guarantee
+// per-record provenance, not by window containment. This helper is
+// the entry point PCAP (#64) and JSONL (#65) rewriters consume —
+// they only have a raw timestamp, no execution identity. Locked-in
+// here per #63's "TimeMap + anchor list" deliverable so the later
+// sub-issues plug in without re-deriving the lookup rule.
+#[allow(dead_code)]
+pub(crate) fn rewrite_ts(
+    real_ts: DateTime<Utc>,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+) -> Result<DateTime<Utc>> {
+    if let Some(anchor) = find_anchor(anchors, real_ts) {
+        anchor
+            .logical_start
+            .checked_add_signed(real_ts - anchor.real_start)
+            .ok_or_else(|| anyhow!("anchor-based rewrite overflows DateTime range"))
+    } else {
+        time_map.to_logical(real_ts)
+    }
+}
+
+/// Returns the anchor whose window contains `ts`. Under overlapping
+/// windows, the deterministic pick is the one with the latest
+/// `real_start` not exceeding `ts`.
+//
+// Kept private; reachable only via `rewrite_ts`. See its allow note
+// for the #63 → #64/#65 hand-off rationale.
+#[allow(dead_code)]
+fn find_anchor(anchors: &[ExecAnchor], ts: DateTime<Utc>) -> Option<&ExecAnchor> {
+    anchors
+        .iter()
+        .filter(|a| a.real_start <= ts && ts <= a.real_end)
+        .max_by_key(|a| a.real_start)
+}
+
+/// Converts a logical-time offset to its real-time equivalent under
+/// the current scale. Kept as a pure helper so the scheduler call site
+/// can convert authored `start_offset`s without coupling to `TimeMap`
+/// construction state.
+pub(crate) fn logical_offset_to_real(
+    offset: Duration,
+    logical_us: i64,
+    real_us: i64,
+) -> Result<Duration> {
+    ensure!(logical_us > 0, "logical duration must be strictly positive");
+    ensure!(real_us > 0, "scenario duration must be strictly positive");
+    let offset_us = offset
+        .num_microseconds()
+        .context("logical offset exceeds microsecond range")?;
+    let scaled = i128::from(offset_us) * i128::from(real_us) / i128::from(logical_us);
+    let scaled_us =
+        i64::try_from(scaled).map_err(|_| anyhow!("scaled real offset overflows i64"))?;
+    Ok(Duration::microseconds(scaled_us))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::activity::Execution;
+    use crate::scenario::Protocol;
+
+    fn fixed(ts: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(ts, 0).unwrap()
+    }
+
+    fn identity_map(start: DateTime<Utc>) -> TimeMap {
+        TimeMap::new(
+            start,
+            start,
+            Duration::try_seconds(300).unwrap(),
+            Duration::try_seconds(300).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn make_exec(start: DateTime<Utc>, end: DateTime<Utc>, src: &str, dst: &str) -> Execution {
+        Execution {
+            start,
+            end,
+            source: src.into(),
+            target: dst.into(),
+            protocol: Protocol::Tcp,
+            src_ip: Ipv4Addr::new(10, 0, 0, 2),
+            src_port: 0,
+            dst_ip: Ipv4Addr::new(10, 0, 0, 3),
+            dst_port: 80,
+            attack: None,
+            exit_code: 0,
+            command: String::new(),
+        }
+    }
+
+    // ── TimeMap ───────────────────────────────────────────────────
+
+    #[test]
+    fn identity_map_returns_real_unchanged() {
+        let start = fixed(1_737_000_000);
+        let tm = identity_map(start);
+        let ts = fixed(1_737_000_120);
+        assert_eq!(tm.to_logical(ts).unwrap(), ts);
+    }
+
+    #[test]
+    fn compression_maps_real_to_logical() {
+        // 30 real minutes → 14 logical days (factor 672).
+        let real_start = fixed(1_000_000_000);
+        let logical_start = fixed(2_000_000_000);
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        // 15 real minutes in → halfway through 14 logical days.
+        let real_mid = real_start + Duration::try_minutes(15).unwrap();
+        let logical_mid = tm.to_logical(real_mid).unwrap();
+        let expected = logical_start + Duration::try_days(7).unwrap();
+        assert_eq!(logical_mid, expected);
+    }
+
+    #[test]
+    fn compression_boundary_does_not_overflow_i128_intermediate() {
+        // 30 real minutes → 14 logical days. Real delta near 30 min
+        // makes the i64-intermediate product exceed ~9.2e18; this test
+        // confirms the i128 intermediate keeps the math correct.
+        let real_start = fixed(0);
+        let tm = TimeMap::new(
+            fixed(0),
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        // 30 real minutes = 1.8e9 µs; 14d = 1.21e12 µs.
+        // Product = 1.8e9 * 1.21e12 = 2.18e21, well past i64 limit.
+        let real_end = real_start + Duration::try_minutes(30).unwrap();
+        let logical_end = tm.to_logical(real_end).unwrap();
+        let expected = fixed(0) + Duration::try_days(14).unwrap();
+        assert_eq!(logical_end, expected);
+    }
+
+    #[test]
+    fn time_map_rejects_zero_durations() {
+        let t = fixed(0);
+        let zero = Duration::zero();
+        let one_min = Duration::try_minutes(1).unwrap();
+        assert!(TimeMap::new(t, t, zero, one_min).is_err());
+        assert!(TimeMap::new(t, t, one_min, zero).is_err());
+    }
+
+    // ── logical_offset_to_real ────────────────────────────────────
+
+    #[test]
+    fn logical_offset_identity() {
+        let offset = Duration::try_minutes(5).unwrap();
+        let real = logical_offset_to_real(offset, 300_000_000, 300_000_000).unwrap();
+        assert_eq!(real, offset);
+    }
+
+    #[test]
+    fn logical_offset_compressed_shrinks() {
+        // 14d logical / 30m real → 672× compression.
+        // 1d logical offset → 30m/14 real offset ≈ 128.57s.
+        let logical_us = Duration::try_days(14).unwrap().num_microseconds().unwrap();
+        let real_us = Duration::try_minutes(30)
+            .unwrap()
+            .num_microseconds()
+            .unwrap();
+        let offset = Duration::try_days(1).unwrap();
+        let real = logical_offset_to_real(offset, logical_us, real_us).unwrap();
+        // Expected: 1d * 30m / 14d = 30m/14 = 128571428 µs ≈ 128.57 s
+        let expected = Duration::microseconds(
+            i64::try_from(
+                i128::from(offset.num_microseconds().unwrap()) * i128::from(real_us)
+                    / i128::from(logical_us),
+            )
+            .unwrap(),
+        );
+        assert_eq!(real, expected);
+    }
+
+    #[test]
+    fn logical_offset_to_real_boundary_uses_i128() {
+        // Same boundary as TimeMap: 14d offset under 14d/30m scale
+        // produces real = 30m. The intermediate product overflows i64.
+        let logical_us = Duration::try_days(14).unwrap().num_microseconds().unwrap();
+        let real_us = Duration::try_minutes(30)
+            .unwrap()
+            .num_microseconds()
+            .unwrap();
+        let offset = Duration::try_days(14).unwrap();
+        let real = logical_offset_to_real(offset, logical_us, real_us).unwrap();
+        assert_eq!(real, Duration::try_minutes(30).unwrap());
+    }
+
+    #[test]
+    fn logical_offset_rejects_zero_logical() {
+        let offset = Duration::try_seconds(1).unwrap();
+        assert!(logical_offset_to_real(offset, 0, 1).is_err());
+    }
+
+    // ── build_anchors ─────────────────────────────────────────────
+
+    #[test]
+    fn build_anchors_drain_clamp_no_overlap() {
+        // Two back-to-back executions whose real spacing is less than
+        // CAPTURE_DRAIN_SECS — the earlier anchor's real_end must be
+        // clamped to the later anchor's real_start.
+        let t0 = fixed(1_000_000_000);
+        let a = make_exec(t0, t0, "a", "x");
+        let b = make_exec(
+            t0 + Duration::milliseconds(500),
+            t0 + Duration::milliseconds(500),
+            "b",
+            "y",
+        );
+        let tm = identity_map(t0);
+        let (anchors, warnings) = build_anchors(&[a, b], &tm).unwrap();
+        assert_eq!(anchors.len(), 2);
+        assert!(warnings.is_empty());
+        assert_eq!(anchors[0].real_end, anchors[1].real_start);
+    }
+
+    #[test]
+    fn build_anchors_tail_keeps_full_drain() {
+        let t0 = fixed(1_000_000_000);
+        let a = make_exec(t0, t0, "a", "x");
+        let tm = identity_map(t0);
+        let (anchors, _) = build_anchors(&[a], &tm).unwrap();
+        let expected_end =
+            t0 + Duration::try_seconds(i64::try_from(CAPTURE_DRAIN_SECS).unwrap()).unwrap();
+        assert_eq!(anchors[0].real_end, expected_end);
+    }
+
+    #[test]
+    fn build_anchors_same_start_produces_overlap_warning() {
+        let t0 = fixed(1_000_000_000);
+        let a = make_exec(t0, t0 + Duration::try_seconds(2).unwrap(), "a", "x");
+        let b = make_exec(t0, t0 + Duration::try_seconds(2).unwrap(), "b", "y");
+        let tm = identity_map(t0);
+        let (_, warnings) = build_anchors(&[a, b], &tm).unwrap();
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn detect_overlaps_empty_for_back_to_back_clamped_windows() {
+        let t0 = fixed(1_000_000_000);
+        let anchors = vec![
+            ExecAnchor {
+                real_start: t0,
+                real_end: t0 + Duration::milliseconds(500),
+                logical_start: t0,
+                source: "a".into(),
+                target: "x".into(),
+            },
+            ExecAnchor {
+                real_start: t0 + Duration::milliseconds(500),
+                real_end: t0 + Duration::milliseconds(1500),
+                logical_start: t0 + Duration::milliseconds(500),
+                source: "b".into(),
+                target: "y".into(),
+            },
+        ];
+        assert!(detect_overlaps(&anchors).is_empty());
+    }
+
+    #[test]
+    fn detect_overlaps_flags_hand_rolled_overlapping_anchors() {
+        let t0 = fixed(1_000_000_000);
+        let anchors = vec![
+            ExecAnchor {
+                real_start: t0,
+                real_end: t0 + Duration::try_seconds(5).unwrap(),
+                logical_start: t0,
+                source: "a".into(),
+                target: "x".into(),
+            },
+            ExecAnchor {
+                real_start: t0 + Duration::try_seconds(2).unwrap(),
+                real_end: t0 + Duration::try_seconds(7).unwrap(),
+                logical_start: t0 + Duration::try_seconds(2).unwrap(),
+                source: "b".into(),
+                target: "y".into(),
+            },
+        ];
+        let warnings = detect_overlaps(&anchors);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].a_source, "a");
+        assert_eq!(warnings[0].b_source, "b");
+    }
+
+    // ── rewrite_ts ────────────────────────────────────────────────
+
+    #[test]
+    fn rewrite_anchor_preserves_intra_session_duration() {
+        // Under heavy compression, a record inside the anchor window
+        // keeps its original real spacing — proving intra-session
+        // timing is preserved.
+        let real_start = fixed(0);
+        let logical_start = fixed(1_000_000_000);
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let exec_start = real_start + Duration::try_seconds(10).unwrap();
+        let exec_end = exec_start + Duration::milliseconds(100);
+        let exec = make_exec(exec_start, exec_end, "a", "x");
+        let (anchors, _) = build_anchors(&[exec], &tm).unwrap();
+
+        let rewritten_start = rewrite_ts(exec_start, &tm, &anchors).unwrap();
+        let rewritten_end = rewrite_ts(exec_end, &tm, &anchors).unwrap();
+        // The intra-session gap of 100ms must be preserved exactly.
+        assert_eq!(rewritten_end - rewritten_start, Duration::milliseconds(100));
+    }
+
+    #[test]
+    fn rewrite_outside_anchor_uses_time_map() {
+        let real_start = fixed(0);
+        let logical_start = fixed(1_000_000_000);
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        // No anchors → always falls back to TimeMap.
+        let real_mid = real_start + Duration::try_minutes(15).unwrap();
+        let logical = rewrite_ts(real_mid, &tm, &[]).unwrap();
+        assert_eq!(logical, logical_start + Duration::try_days(7).unwrap());
+    }
+
+    #[test]
+    fn rewrite_inter_session_gap_reflects_authored_offsets() {
+        // Two executions with different real starts under compression:
+        // the rewritten gap between their starts must follow the
+        // logical scale, not the real spacing.
+        let real_start = fixed(0);
+        let logical_start = fixed(1_000_000_000);
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let first_start = real_start + Duration::try_minutes(10).unwrap();
+        let second_start = real_start + Duration::try_minutes(20).unwrap();
+        let a = make_exec(first_start, first_start, "a", "x");
+        let b = make_exec(second_start, second_start, "b", "y");
+        let (anchors, _) = build_anchors(&[a, b], &tm).unwrap();
+
+        // Use the anchors' own logical_start values — these reflect
+        // the global scale because they're computed at anchor
+        // construction by TimeMap::to_logical.
+        let gap = anchors[1].logical_start - anchors[0].logical_start;
+        // 10 real minutes between starts scale to 10 * (14d / 30m) days
+        // = 14d / 3. Verify by formula.
+        let expected = Duration::microseconds(
+            i64::try_from(
+                i128::from(
+                    Duration::try_minutes(10)
+                        .unwrap()
+                        .num_microseconds()
+                        .unwrap(),
+                ) * i128::from(tm.logical_us())
+                    / i128::from(tm.real_us()),
+            )
+            .unwrap(),
+        );
+        assert_eq!(gap, expected);
+    }
+
+    #[test]
+    fn find_anchor_picks_latest_real_start_under_overlap() {
+        let t0 = fixed(1_000_000_000);
+        let anchors = vec![
+            ExecAnchor {
+                real_start: t0,
+                real_end: t0 + Duration::try_seconds(10).unwrap(),
+                logical_start: t0,
+                source: "a".into(),
+                target: "x".into(),
+            },
+            ExecAnchor {
+                real_start: t0 + Duration::try_seconds(3).unwrap(),
+                real_end: t0 + Duration::try_seconds(8).unwrap(),
+                logical_start: t0 + Duration::try_seconds(3).unwrap(),
+                source: "b".into(),
+                target: "y".into(),
+            },
+        ];
+        let ts = t0 + Duration::try_seconds(5).unwrap();
+        let picked = find_anchor(&anchors, ts).unwrap();
+        assert_eq!(picked.source, "b");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `src/time.rs` module that owns the real→logical timestamp mapping (`TimeMap`), per-execution anchors (`ExecAnchor`, `build_anchors`, overlap warnings), and the pure `logical_offset_to_real` helper. These pieces are wired through the pipeline so:

- The scheduler in `src/activity.rs` interprets authored `start_offset`s as logical time and scales them to real time at the call site, leaving `Activity::offset` and the in-memory `Execution.start`/`end` as their real values.
- `assemble_bundle` in `src/main.rs` builds per-execution anchors after `enrich_src_ports`, prints overlap warnings via `eprintln!` in the agreed format, and threads a `TimeMap` plus anchor list into Ground Truth and meta writing.
- `src/ground_truth.rs` rewrites each execution's `start`/`end` through its matching anchor (preserving intra-session duration exactly under compression) and returns the maximum rewritten timestamp so the `meta.json` `actual_end` aggregator can include it.
- `src/meta.rs` now takes a `TimeMap` and a pre-aggregated `actual_end`; `generated_at` is pinned to `real_generation_start`, `duration.actual_start` is the effective `start_at`, and `duration.total` is the logical duration when one was provided.

`TimeMap::to_logical` and `logical_offset_to_real` both use an `i128` intermediate product and `i64::try_from` final narrowing, so realistic compression ratios (e.g., 30 min real → 14 days logical) round-trip without overflow. Each `DateTime + Duration` addition uses `checked_add_signed` and surfaces overflow as an error per the issue's contract.

The pipeline order is now: build `TimeMap` → run activities with scaled offsets → `enrich_src_ports` → `build_anchors` → rewrite GT → write `meta.json` last with the aggregated `actual_end`. The aggregator interface is shaped so #64 (PCAP) and #65 (JSONL) plug in without changing `meta::write`; `rewrite_ts` in `src/time.rs` is in place (marked `#[allow(dead_code)]`) so those sub-issues can call it without re-deriving the lookup rule.

### Identity-case `actual_end` fallback

When neither `start_at` nor `logical_duration` is set (the TimeMap is a 1:1 pass-through, detected via `TimeMap::is_identity()`), `assemble_bundle` skips the rewrite-pass aggregator and sets `actual_end = start + scenario.duration`. This matches the pre-#63 behavior the issue's identity-case acceptance criterion requires and prevents `actual_end` from regressing to the last execution's end-plus-drain when no time rewriting is in effect. Under any compression or shift (`start_at` or `logical_duration` set), the aggregator path runs as before.

Out of scope per the issue itself: PCAP packet header timestamps (#64), Falco / Sysmon JSONL timestamps (#65), and golden fixtures / CI (#66).

Closes #63

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (305 unit tests, including 17 `time::tests::*`, one GT compression test, one `main::tests::assemble_bundle_under_compression_enriches_and_rewrites`, and one `main::tests::assemble_bundle_identity_uses_legacy_actual_end` regression)
- [x] `TimeMap` boundary: 30 min real → 14 days logical maps without `i64` overflow during the intermediate multiply
- [x] `logical_offset_to_real` boundary: same compression scale, 14-day logical offset round-trips to 30 real minutes
- [x] Drain clamping: two back-to-back executions with real spacing < `CAPTURE_DRAIN_SECS` produce no overlap warning, and the earlier anchor's `real_end` equals the later anchor's `real_start`
- [x] Overlap detection: a hand-rolled overlapping anchor list yields one `OverlapWarning` per overlapping pair; the rewrite still completes deterministically
- [x] Intra-session preservation: under compression, a Ground Truth record's `end - start` equals the original real duration (asserted at second precision because `format_ts` truncates sub-seconds)
- [x] Inter-session control: under compression, the gap between two anchors' `logical_start` values reflects the logical scale, not the real spacing
- [x] `pcap::enrich_src_ports` still succeeds on a compressed scenario before any rewrite runs
- [x] `meta.json`: `generated_at` equals `real_generation_start`; `duration.actual_start` equals the effective `start_at`; `duration.actual_end` is the aggregator's max
- [x] Identity case (no `start_at`, no `logical_duration`): `meta.duration.actual_end` equals `start + scenario.duration` exactly as on `main`, asserted by the new `assemble_bundle_identity_uses_legacy_actual_end` test