### PR TITLE
Rewrite Falco and Sysmon JSONL onto logical timeline (#65)

### DIFF
--- a/src/falco.rs
+++ b/src/falco.rs
@@ -4,7 +4,19 @@ use anyhow::{Context, Result, bail};
 use bollard::Docker;
 use bollard::exec::CreateExecOptions;
 use bollard::models::ContainerStateStatusEnum;
+use chrono::{DateTime, FixedOffset, Utc};
 use futures_util::StreamExt;
+
+use crate::time::{ExecAnchor, RewriteDiagnostics, TimeMap, logical_window, rewrite_ts};
+
+/// JSON key for the Falco event timestamp.
+const TIME_KEY: &str = "time";
+/// Format string for Falco's nanosecond-with-numeric-offset form.
+/// `%z` emits the offset without a colon (`+0000`), matching Falco's
+/// Go default output and the validator fixtures.
+const NANOSEC_FMT: &str = "%Y-%m-%dT%H:%M:%S%.9f%z";
+/// Format string for Falco's `Z` (UTC, second-precision) form.
+const Z_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 
 /// Output path inside the Falco sidecar container where JSONL events
 /// are written.
@@ -73,6 +85,179 @@ pub(crate) async fn collect_logs(
     Ok(relative)
 }
 
+/// Rewrites the `time` field of every record in a Falco JSONL file
+/// onto the logical timeline. Returns the max rewritten timestamp
+/// (or `None` when no record was rewritten) and a diagnostic counter
+/// the call site renders into a per-file warning line.
+///
+/// Malformed lines, records missing the `time` field, and unparseable
+/// timestamp values pass through unchanged with their respective
+/// counters incremented. Records whose rewritten timestamp lands
+/// outside the scenario's logical window are kept and counted via
+/// `out_of_window`. Both observed wire formats round-trip byte-for-byte
+/// (nanosecond + `+HHMM` offset, and second-precision `Z`).
+pub(crate) fn rewrite_timestamps(
+    path: &Path,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+) -> Result<(Option<DateTime<Utc>>, RewriteDiagnostics)> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let (start, end) = logical_window(time_map)?;
+
+    let mut diag = RewriteDiagnostics::default();
+    let mut max_ts: Option<DateTime<Utc>> = None;
+    let mut output = String::with_capacity(content.len());
+
+    for raw_line in content.split_inclusive('\n') {
+        let (body, eol) = split_eol(raw_line);
+        if body.is_empty() {
+            output.push_str(raw_line);
+            continue;
+        }
+
+        let new_body = match rewrite_falco_line(
+            body,
+            time_map,
+            anchors,
+            &mut diag,
+            &mut max_ts,
+            start,
+            end,
+        )? {
+            Some(s) => s,
+            None => body.to_owned(),
+        };
+        output.push_str(&new_body);
+        output.push_str(eol);
+    }
+
+    std::fs::write(path, &output).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok((max_ts, diag))
+}
+
+fn split_eol(raw: &str) -> (&str, &str) {
+    raw.strip_suffix('\n')
+        .map_or((raw, ""), |body| (body, "\n"))
+}
+
+/// Rewrites a single Falco JSONL line. Returns `Some(new_body)` when
+/// the timestamp was successfully rewritten, `None` when the line was
+/// passed through (with the appropriate counter incremented).
+fn rewrite_falco_line(
+    body: &str,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+    diag: &mut RewriteDiagnostics,
+    max_ts: &mut Option<DateTime<Utc>>,
+    window_start: DateTime<Utc>,
+    window_end: DateTime<Utc>,
+) -> Result<Option<String>> {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) else {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    };
+    if !parsed.is_object() {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    }
+    let Some(time_value) = parsed.get(TIME_KEY) else {
+        diag.missing_field += 1;
+        return Ok(None);
+    };
+    let Some(time_str) = time_value.as_str() else {
+        diag.unparseable_ts += 1;
+        return Ok(None);
+    };
+    let Some((real_ts, style, offset)) = parse_falco_time(time_str) else {
+        diag.unparseable_ts += 1;
+        return Ok(None);
+    };
+
+    let rewritten = rewrite_ts(real_ts, time_map, anchors)?;
+    let new_value = format_falco_time(rewritten, style, offset);
+    let Some(new_body) = substitute_field_value(body, TIME_KEY, &new_value) else {
+        // Field is present per the JSON parse but not locatable by
+        // raw substring search — exotic whitespace inside the line.
+        // Treat as malformed and leave the line byte-identical rather
+        // than emitting an incorrect rewrite.
+        diag.malformed_lines += 1;
+        return Ok(None);
+    };
+
+    if rewritten < window_start || rewritten > window_end {
+        diag.out_of_window += 1;
+    }
+    if max_ts.is_none_or(|m| rewritten > m) {
+        *max_ts = Some(rewritten);
+    }
+    Ok(Some(new_body))
+}
+
+#[derive(Clone, Copy)]
+enum FalcoStyle {
+    /// `2026-01-15T09:01:00.000000000+0000` (nanosecond, numeric offset
+    /// without a colon).
+    NanoOffsetNoColon,
+    /// `2026-01-15T09:01:00Z` (second precision, UTC).
+    ZSeconds,
+}
+
+fn parse_falco_time(s: &str) -> Option<(DateTime<Utc>, FalcoStyle, FixedOffset)> {
+    if s.ends_with('Z')
+        && let Ok(dt) = DateTime::parse_from_rfc3339(s)
+    {
+        return Some((dt.with_timezone(&Utc), FalcoStyle::ZSeconds, *dt.offset()));
+    }
+    if let Ok(dt) = DateTime::parse_from_str(s, NANOSEC_FMT) {
+        return Some((
+            dt.with_timezone(&Utc),
+            FalcoStyle::NanoOffsetNoColon,
+            *dt.offset(),
+        ));
+    }
+    None
+}
+
+fn format_falco_time(utc: DateTime<Utc>, style: FalcoStyle, offset: FixedOffset) -> String {
+    match style {
+        FalcoStyle::ZSeconds => utc.format(Z_FMT).to_string(),
+        FalcoStyle::NanoOffsetNoColon => utc.with_timezone(&offset).format(NANOSEC_FMT).to_string(),
+    }
+}
+
+/// Replaces the string value of `field` in a compact JSON line with
+/// `new_value`, byte-for-byte, leaving every other byte intact.
+///
+/// Searches for the literal `"<field>":"`, then scans forward to the
+/// next unescaped `"` (respecting backslash escapes so wire-form
+/// `\/Date(…)\/` survives intact in Sysmon). Returns `None` when the
+/// pattern is not present.
+pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) -> Option<String> {
+    let needle = format!("\"{field}\":\"");
+    let key_pos = raw.find(&needle)?;
+    let value_start = key_pos + needle.len();
+
+    let bytes = raw.as_bytes();
+    let mut end = value_start;
+    while end < bytes.len() {
+        match bytes.get(end)? {
+            b'\\' if end + 1 < bytes.len() => end += 2,
+            b'"' => break,
+            _ => end += 1,
+        }
+    }
+    if end >= bytes.len() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(raw.len() + new_value.len());
+    out.push_str(&raw[..value_start]);
+    out.push_str(new_value);
+    out.push_str(&raw[end..]);
+    Some(out)
+}
+
 /// Checks whether a container is currently running.
 async fn is_running(docker: &Docker, container_id: &str) -> Result<bool> {
     let info = docker
@@ -139,7 +324,273 @@ async fn exec_output(docker: &Docker, container_id: &str, command: &str) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use chrono::{Duration, TimeZone};
+
     use super::*;
+    use crate::activity::Execution;
+    use crate::scenario::Protocol;
+    use crate::time::build_anchors;
+
+    // ── helpers ───────────────────────────────────────────────────
+
+    const FALCO_NS: &str = r#"{"time":"2026-01-15T09:01:00.000000000+0000","rule":"r","priority":"Notice","output":"x"}"#;
+    const FALCO_Z: &str = r#"{"time":"2026-01-15T09:01:00Z","rule":"r","priority":"Notice"}"#;
+
+    fn identity_map() -> TimeMap {
+        let t = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let dur = Duration::try_minutes(5).unwrap();
+        TimeMap::new(t, t, dur, dur).unwrap()
+    }
+
+    fn write_lines(dir: &Path, lines: &[&str]) -> PathBuf {
+        let p = dir.join("falco.jsonl");
+        let mut content = String::new();
+        for l in lines {
+            content.push_str(l);
+            content.push('\n');
+        }
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    fn make_exec(start: DateTime<Utc>, end: DateTime<Utc>) -> Execution {
+        Execution {
+            start,
+            end,
+            source: "a".into(),
+            target: "b".into(),
+            protocol: Protocol::Tcp,
+            src_ip: std::net::Ipv4Addr::new(10, 0, 0, 2),
+            src_port: 0,
+            dst_ip: std::net::Ipv4Addr::new(10, 0, 0, 3),
+            dst_port: 80,
+            attack: None,
+            exit_code: 0,
+            command: String::new(),
+        }
+    }
+
+    // ── round-trip under identity ─────────────────────────────────
+
+    #[test]
+    fn identity_preserves_nanosecond_format_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[FALCO_NS]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn identity_preserves_nonzero_nanosecond_fraction_byte_for_byte() {
+        // Real Falco emits full nanosecond precision; under identity
+        // the rewrite must not truncate the sub-microsecond tail.
+        let dir = tempfile::tempdir().unwrap();
+        let line =
+            r#"{"time":"2026-01-15T09:01:00.123456789+0000","rule":"r","priority":"Notice"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert_eq!(
+            max_ts.unwrap().timestamp_subsec_nanos(),
+            123_456_789,
+            "identity rewrite must preserve nanosecond precision",
+        );
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn identity_preserves_z_format_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[FALCO_Z]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    // ── anchor preservation ───────────────────────────────────────
+
+    #[test]
+    fn anchor_burst_preserves_intra_session_spacing() {
+        // 30 real minutes → 14 logical days. Two Falco records inside
+        // one execution window must keep their real 100 ms spacing
+        // and land at the execution's logical_start.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let exec_start = real_start + Duration::try_seconds(10).unwrap();
+        let exec_end = exec_start + Duration::try_seconds(1).unwrap();
+        let (anchors, _) = build_anchors(&[make_exec(exec_start, exec_end)], &tm).unwrap();
+
+        let line_a = format!(
+            r#"{{"time":"{}","rule":"a"}}"#,
+            exec_start.format(NANOSEC_FMT)
+        );
+        let burst_b = exec_start + Duration::milliseconds(100);
+        let line_b = format!(r#"{{"time":"{}","rule":"b"}}"#, burst_b.format(NANOSEC_FMT));
+
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[&line_a, &line_b]);
+        let (max_ts, diag) = rewrite_timestamps(&p, &tm, &anchors).unwrap();
+        assert!(diag.is_empty());
+
+        // Both records' rewritten times must be parseable; their delta
+        // is 100 ms; first record lands exactly at the anchor's
+        // `logical_start` (no scaling inside the window).
+        let content = std::fs::read_to_string(&p).unwrap();
+        let lines: Vec<_> = content.lines().collect();
+        let ts_a: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let ts_b: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        let a = DateTime::parse_from_str(ts_a["time"].as_str().unwrap(), NANOSEC_FMT).unwrap();
+        let b = DateTime::parse_from_str(ts_b["time"].as_str().unwrap(), NANOSEC_FMT).unwrap();
+        assert_eq!(a.with_timezone(&Utc), anchors[0].logical_start);
+        assert_eq!(b - a, Duration::milliseconds(100));
+        assert_eq!(max_ts.unwrap(), b.with_timezone(&Utc));
+        // Sanity: the anchor's logical_start is the global-map image
+        // of `exec_start`, *not* the bare `logical_start` constant we
+        // chose for the run — under compression, `exec_start`'s
+        // 10-second offset from `real_start` is scaled.
+        assert_ne!(anchors[0].logical_start, logical_start);
+    }
+
+    // ── out-of-window fallback uses TimeMap ───────────────────────
+
+    #[test]
+    fn record_outside_anchor_uses_global_time_map() {
+        // No anchors → every record goes through the global map.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let real_mid = real_start + Duration::try_minutes(15).unwrap();
+        let line = format!(r#"{{"time":"{}"}}"#, real_mid.format(NANOSEC_FMT));
+
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[&line]);
+        let (max_ts, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        // 15 real minutes through a 30 m → 14 d compression = 7 logical days.
+        assert_eq!(
+            max_ts.unwrap(),
+            logical_start + Duration::try_days(7).unwrap(),
+        );
+    }
+
+    // ── edge cases ────────────────────────────────────────────────
+
+    #[test]
+    fn missing_time_field_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"rule":"r","output":"no timestamp here"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.missing_field, 1);
+        assert_eq!(diag.malformed_lines, 0);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn malformed_json_line_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":"2026-01-15T09:01:00Z","rule":"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn unparseable_timestamp_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":"not a timestamp","rule":"r"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.unparseable_ts, 1);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn out_of_window_timestamp_keeps_record_and_counts() {
+        // Logical window is `start_at + 5m`; emit a record whose real
+        // timestamp lands 10 logical minutes past it under identity
+        // scale. The rewritten record is kept; only the counter is
+        // incremented.
+        let line = r#"{"time":"2026-01-15T09:10:00Z","rule":"r"}"#;
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[line]);
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.out_of_window, 1);
+        assert!(max_ts.is_some());
+        // Record retained: the file still contains one line.
+        let content = std::fs::read_to_string(&p).unwrap();
+        assert_eq!(content.lines().count(), 1);
+    }
+
+    // ── aggregator contract ───────────────────────────────────────
+
+    #[test]
+    fn empty_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("falco.jsonl");
+        std::fs::write(&p, "").unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(max_ts.is_none());
+        assert!(diag.is_empty());
+    }
+
+    #[test]
+    fn all_passthrough_lines_return_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(
+            dir.path(),
+            &[r#"{"rule":"missing-ts"}"#, r"not json at all"],
+        );
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(max_ts.is_none());
+        assert_eq!(diag.missing_field, 1);
+        assert_eq!(diag.malformed_lines, 1);
+    }
+
+    #[test]
+    fn multi_record_returns_max_rewritten_ts() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(
+            dir.path(),
+            &[
+                r#"{"time":"2026-01-15T09:01:00Z"}"#,
+                r#"{"time":"2026-01-15T09:02:30Z"}"#,
+                r#"{"time":"2026-01-15T09:02:00Z"}"#,
+            ],
+        );
+        let (max_ts, _) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(
+            max_ts.unwrap(),
+            Utc.with_ymd_and_hms(2026, 1, 15, 9, 2, 30).unwrap(),
+        );
+    }
 
     #[test]
     fn container_output_path_is_absolute() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,15 @@ fn assemble_bundle(
     }
     println!("Rewrote pcap timestamps");
 
+    rewrite_telemetry_jsonl(
+        output_dir,
+        telemetry,
+        time_map,
+        &anchors,
+        identity_run,
+        &mut actual_end,
+    )?;
+
     let scenario_filename = Path::new(scenario_path).file_name().map_or_else(
         || scenario_path.to_owned(),
         |n| n.to_string_lossy().into_owned(),
@@ -332,6 +341,46 @@ fn assemble_bundle(
     )?;
     println!("Wrote meta.json");
 
+    Ok(())
+}
+
+/// Rewrites timestamps in Falco and Sysmon JSONL files onto the
+/// logical timeline. Iterates the telemetry triples already collected
+/// upstream and dispatches to the per-kind rewriter. Aggregates the
+/// max rewritten timestamp into `actual_end` (unless this is an
+/// identity run, in which case the aggregator is pinned to
+/// `start + scenario.duration` upstream and JSONL contributions are
+/// intentionally discarded). Prints one diagnostic summary line per
+/// file when any pass-through counter is non-zero.
+fn rewrite_telemetry_jsonl(
+    output_dir: &Path,
+    telemetry: &[(String, String, String)],
+    time_map: &time::TimeMap,
+    anchors: &[time::ExecAnchor],
+    identity_run: bool,
+    actual_end: &mut DateTime<Utc>,
+) -> Result<()> {
+    for (_host, kind, rel_path) in telemetry {
+        let abs_path = output_dir.join(rel_path);
+        let (max_ts, diag) = match kind.as_str() {
+            "falco" => falco::rewrite_timestamps(&abs_path, time_map, anchors)?,
+            "sysmon" => sysmon::rewrite_timestamps(&abs_path, time_map, anchors)?,
+            _ => continue,
+        };
+        if !diag.is_empty() {
+            eprintln!(
+                "warning: {rel_path}: {} malformed line(s), {} missing field(s), \
+                 {} unparseable timestamp(s); {} record(s) outside logical window",
+                diag.malformed_lines, diag.missing_field, diag.unparseable_ts, diag.out_of_window,
+            );
+        }
+        if !identity_run
+            && let Some(ts) = max_ts
+            && ts > *actual_end
+        {
+            *actual_end = ts;
+        }
+    }
     Ok(())
 }
 

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -1,8 +1,15 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 
+use crate::falco::substitute_field_value;
+use crate::time::{ExecAnchor, RewriteDiagnostics, TimeMap, logical_window, rewrite_ts};
 use crate::vm::{self, ProvisionedVm};
+
+/// JSON key for the Sysmon event timestamp emitted by
+/// `Get-WinEvent | ConvertTo-Json -Compress`.
+const TIME_KEY: &str = "TimeCreated";
 
 /// Minimal Sysmon configuration (SwiftOnSecurity-inspired baseline).
 ///
@@ -124,8 +131,231 @@ pub(crate) async fn collect_logs(vm_host: &ProvisionedVm, output_dir: &Path) -> 
     Ok(relative)
 }
 
+/// Rewrites the `TimeCreated` field of every record in a Sysmon
+/// JSONL file onto the logical timeline. See `falco::rewrite_timestamps`
+/// for the shared contract; the only Sysmon-specific behavior is the
+/// dual wire format (`\/Date(<ms>)\/` for Windows PowerShell 5.1, ISO
+/// 8601 for PowerShell 7+) and the requirement to preserve the input
+/// offset and fractional precision on round-trip.
+pub(crate) fn rewrite_timestamps(
+    path: &Path,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+) -> Result<(Option<DateTime<Utc>>, RewriteDiagnostics)> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let (start, end) = logical_window(time_map)?;
+
+    let mut diag = RewriteDiagnostics::default();
+    let mut max_ts: Option<DateTime<Utc>> = None;
+    let mut output = String::with_capacity(content.len());
+
+    for raw_line in content.split_inclusive('\n') {
+        let (body, eol) = raw_line
+            .strip_suffix('\n')
+            .map_or((raw_line, ""), |b| (b, "\n"));
+        if body.is_empty() {
+            output.push_str(raw_line);
+            continue;
+        }
+        let new_body =
+            match rewrite_sysmon_line(body, time_map, anchors, &mut diag, &mut max_ts, start, end)?
+            {
+                Some(s) => s,
+                None => body.to_owned(),
+            };
+        output.push_str(&new_body);
+        output.push_str(eol);
+    }
+
+    std::fs::write(path, &output).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok((max_ts, diag))
+}
+
+fn rewrite_sysmon_line(
+    body: &str,
+    time_map: &TimeMap,
+    anchors: &[ExecAnchor],
+    diag: &mut RewriteDiagnostics,
+    max_ts: &mut Option<DateTime<Utc>>,
+    window_start: DateTime<Utc>,
+    window_end: DateTime<Utc>,
+) -> Result<Option<String>> {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) else {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    };
+    if !parsed.is_object() {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    }
+    if parsed.get(TIME_KEY).is_none() {
+        diag.missing_field += 1;
+        return Ok(None);
+    }
+    let Some(raw_value) = locate_raw_value(body, TIME_KEY) else {
+        diag.missing_field += 1;
+        return Ok(None);
+    };
+    let Some((real_ts, style)) = parse_sysmon_time(raw_value) else {
+        diag.unparseable_ts += 1;
+        return Ok(None);
+    };
+
+    let rewritten = rewrite_ts(real_ts, time_map, anchors)?;
+    let new_value = format_sysmon_time(rewritten, &style);
+    let Some(new_body) = substitute_field_value(body, TIME_KEY, &new_value) else {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    };
+
+    if rewritten < window_start || rewritten > window_end {
+        diag.out_of_window += 1;
+    }
+    if max_ts.is_none_or(|m| rewritten > m) {
+        *max_ts = Some(rewritten);
+    }
+    Ok(Some(new_body))
+}
+
+/// Reads the raw on-wire bytes between the field's opening and closing
+/// quotes without unescaping. Required so the PowerShell 5.1 form
+/// `\/Date(<ms>)\/` is recognized verbatim.
+fn locate_raw_value<'a>(raw: &'a str, field: &str) -> Option<&'a str> {
+    let needle = format!("\"{field}\":\"");
+    let key_pos = raw.find(&needle)?;
+    let value_start = key_pos + needle.len();
+    let bytes = raw.as_bytes();
+    let mut end = value_start;
+    while end < bytes.len() {
+        match bytes.get(end)? {
+            b'\\' if end + 1 < bytes.len() => end += 2,
+            b'"' => break,
+            _ => end += 1,
+        }
+    }
+    if end >= bytes.len() {
+        return None;
+    }
+    Some(&raw[value_start..end])
+}
+
+enum SysmonStyle {
+    /// `/Date(<ms>)/`. `escaped` records whether the on-wire slashes
+    /// were backslash-escaped (`\/Date(<ms>)\/`, the Windows
+    /// PowerShell 5.1 default) or bare (`/Date(<ms>)/`, what some
+    /// serde re-encoders emit). The spelling is preserved on write.
+    DateMs { escaped: bool },
+    /// PowerShell 7+ ISO 8601 with `Z`. `frac_digits` is the number of
+    /// digits after the decimal point in the original input.
+    IsoZ { frac_digits: usize },
+    /// PowerShell 7+ ISO 8601 with a numeric offset (e.g. `+09:00`).
+    IsoOffset {
+        offset: FixedOffset,
+        frac_digits: usize,
+    },
+}
+
+fn parse_sysmon_time(raw_value: &str) -> Option<(DateTime<Utc>, SysmonStyle)> {
+    // `/Date(<ms>)/` with either escaped or bare slashes. The
+    // escaped form is the PowerShell 5.1 wire default; the bare form
+    // is what some serde re-encoders emit after a parse round-trip.
+    // Both must round-trip in their original spelling.
+    for (prefix, suffix, escaped) in [("\\/Date(", ")\\/", true), ("/Date(", ")/", false)] {
+        if let Some(inner) = raw_value
+            .strip_prefix(prefix)
+            .and_then(|r| r.strip_suffix(suffix))
+        {
+            let ms: i64 = inner.parse().ok()?;
+            let utc = Utc.timestamp_millis_opt(ms).single()?;
+            return Some((utc, SysmonStyle::DateMs { escaped }));
+        }
+    }
+    // ISO 8601. Chrono's RFC 3339 parser accepts both `Z` and `±HH:MM`.
+    let dt = DateTime::parse_from_rfc3339(raw_value).ok()?;
+    let frac_digits = count_frac_digits(raw_value);
+    let style = if raw_value.ends_with('Z') {
+        SysmonStyle::IsoZ { frac_digits }
+    } else {
+        SysmonStyle::IsoOffset {
+            offset: *dt.offset(),
+            frac_digits,
+        }
+    };
+    Some((dt.with_timezone(&Utc), style))
+}
+
+fn count_frac_digits(s: &str) -> usize {
+    let Some(dot_pos) = s.find('.') else {
+        return 0;
+    };
+    s[dot_pos + 1..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .count()
+}
+
+fn format_sysmon_time(utc: DateTime<Utc>, style: &SysmonStyle) -> String {
+    match style {
+        SysmonStyle::DateMs { escaped: true } => {
+            format!("\\/Date({})\\/", utc.timestamp_millis())
+        }
+        SysmonStyle::DateMs { escaped: false } => {
+            format!("/Date({})/", utc.timestamp_millis())
+        }
+        SysmonStyle::IsoZ { frac_digits } => format_iso(utc, None, *frac_digits),
+        SysmonStyle::IsoOffset {
+            offset,
+            frac_digits,
+        } => format_iso(utc, Some(*offset), *frac_digits),
+    }
+}
+
+/// Emits an ISO 8601 timestamp with arbitrary fractional precision
+/// (`%.Nf` is only defined for N ∈ {3, 6, 9} in chrono). When `offset`
+/// is `None`, the suffix is `Z`; otherwise the suffix is `±HH:MM`.
+fn format_iso(utc: DateTime<Utc>, offset: Option<FixedOffset>, frac_digits: usize) -> String {
+    let head = match offset {
+        None => utc.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        Some(ofs) => utc
+            .with_timezone(&ofs)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+    };
+    let frac = if frac_digits == 0 {
+        String::new()
+    } else {
+        let nanos = utc.timestamp_subsec_nanos();
+        let nanos_str = format!("{nanos:09}");
+        let truncated = if frac_digits <= 9 {
+            nanos_str[..frac_digits].to_string()
+        } else {
+            // Sub-nanosecond inputs (e.g. .NET's 7 digits is fine, but
+            // we still handle padding for any future precision bump).
+            format!("{}{}", nanos_str, "0".repeat(frac_digits - 9))
+        };
+        format!(".{truncated}")
+    };
+    let tail = match offset {
+        None => "Z".to_string(),
+        Some(ofs) => format_offset(ofs),
+    };
+    format!("{head}{frac}{tail}")
+}
+
+fn format_offset(offset: FixedOffset) -> String {
+    let secs = offset.local_minus_utc();
+    let sign = if secs < 0 { '-' } else { '+' };
+    let abs = secs.unsigned_abs();
+    let h = abs / 3600;
+    let m = (abs % 3600) / 60;
+    format!("{sign}{h:02}:{m:02}")
+}
+
 #[cfg(test)]
 mod tests {
+    use chrono::Duration;
+
     use super::*;
 
     #[test]
@@ -156,6 +386,297 @@ mod tests {
         assert!(
             !SYSMON_CONFIG_XML.contains('\''),
             "config XML must not contain single quotes (breaks PowerShell embedding)",
+        );
+    }
+
+    // ── rewrite_timestamps ────────────────────────────────────────
+
+    fn identity_map() -> TimeMap {
+        let t = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let dur = Duration::try_minutes(5).unwrap();
+        TimeMap::new(t, t, dur, dur).unwrap()
+    }
+
+    fn write_lines(dir: &Path, lines: &[&str]) -> PathBuf {
+        let p = dir.join("sysmon.jsonl");
+        let mut content = String::new();
+        for l in lines {
+            content.push_str(l);
+            content.push('\n');
+        }
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    /// `Date(<ms>)` payload for `2026-01-15T09:01:15Z` — `1768467675000`.
+    const DATE_MS_LINE: &str = r#"{"TimeCreated":"\/Date(1768467675000)\/","Id":4688}"#;
+    /// Bare `/Date(<ms>)/` — what some serde re-encoders produce.
+    const DATE_MS_BARE_LINE: &str = r#"{"TimeCreated":"/Date(1768467675000)/","Id":4688}"#;
+    const ISO_Z_LINE: &str = r#"{"TimeCreated":"2026-01-15T09:01:15Z","Id":4688}"#;
+    const ISO_OFFSET_LINE: &str = r#"{"TimeCreated":"2026-01-15T18:01:15+09:00","Id":4688}"#;
+
+    #[test]
+    fn identity_preserves_date_ms_wire_form_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[DATE_MS_LINE]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        // Critically, the escaped slashes must survive: read the file
+        // back as raw bytes and assert equality, then also verify the
+        // backslash bytes are present.
+        let written = std::fs::read(&p).unwrap();
+        assert_eq!(written, original);
+        assert!(
+            std::str::from_utf8(&written).unwrap().contains(r"\/Date("),
+            "escaped slashes must survive the round-trip",
+        );
+    }
+
+    #[test]
+    fn identity_preserves_bare_date_ms_byte_for_byte() {
+        // Bare `/Date(<ms>)/` (no escaped slashes) must also round-trip
+        // byte-for-byte and NOT be converted to the escaped spelling.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[DATE_MS_BARE_LINE]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        let written = std::fs::read(&p).unwrap();
+        assert_eq!(written, original);
+        let s = std::str::from_utf8(&written).unwrap();
+        assert!(
+            s.contains("/Date(") && !s.contains(r"\/Date("),
+            "bare slashes must NOT be promoted to escaped slashes: {s}",
+        );
+    }
+
+    #[test]
+    fn bare_date_ms_rewrites_under_compression_keeps_bare_slashes() {
+        // Same scenario as `date_ms_rewrites_under_compression` but the
+        // input is the bare-slash spelling. The rewritten line must
+        // keep bare slashes, not switch to the escaped form.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[DATE_MS_BARE_LINE]);
+        let (_, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        let s = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            s.contains("/Date(") && !s.contains(r"\/Date("),
+            "rewritten value must keep bare slashes: {s}",
+        );
+    }
+
+    #[test]
+    fn identity_preserves_iso_z_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[ISO_Z_LINE]);
+        let original = std::fs::read(&p).unwrap();
+        let (_, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn identity_preserves_iso_offset_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[ISO_OFFSET_LINE]);
+        let original = std::fs::read(&p).unwrap();
+        let (_, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        // The `+09:00` offset must NOT be normalized to `Z`.
+        let s = std::fs::read_to_string(&p).unwrap();
+        assert!(s.contains("+09:00"));
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn iso_offset_input_keeps_offset_on_rewrite() {
+        // Under a non-identity map, the rewritten value must still
+        // emit `+09:00`, not `Z`. We use a compression map and check
+        // the suffix.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        // 2026-01-15T18:01:15+09:00 == 2026-01-15T09:01:15Z (75 s past
+        // real_start). Within the 30-min real window.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[ISO_OFFSET_LINE]);
+        let (_, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        let s = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            s.contains("+09:00") && !s.contains('Z'),
+            "rewritten value must preserve the +09:00 offset: {s}",
+        );
+    }
+
+    #[test]
+    fn iso_with_microsecond_fractional_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15.123456Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (_, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn iso_with_seven_digit_dotnet_fractional_round_trips() {
+        // PowerShell 7+ default `.ToString("o")` form carries 7
+        // fractional digits (100 ns ticks). Identity must preserve
+        // every digit, not truncate to microseconds.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15.1234567Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert_eq!(
+            max_ts.unwrap().timestamp_subsec_nanos(),
+            123_456_700,
+            "identity rewrite must preserve 100 ns ticks",
+        );
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn iso_with_nine_digit_nanosecond_fractional_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15.123456789Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert_eq!(max_ts.unwrap().timestamp_subsec_nanos(), 123_456_789);
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    // ── edge cases ────────────────────────────────────────────────
+
+    #[test]
+    fn missing_field_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"Id":4688,"Message":"no timestamp"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.missing_field, 1);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn malformed_line_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15Z""#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn unparseable_timestamp_passes_through_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"not a timestamp","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.unparseable_ts, 1);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn out_of_window_keeps_record_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        // 10 logical minutes past the 5-minute window under identity.
+        let line = r#"{"TimeCreated":"2026-01-15T09:10:00Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.out_of_window, 1);
+        assert!(max_ts.is_some());
+        let content = std::fs::read_to_string(&p).unwrap();
+        assert_eq!(content.lines().count(), 1);
+    }
+
+    // ── aggregator contract ───────────────────────────────────────
+
+    #[test]
+    fn empty_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("sysmon.jsonl");
+        std::fs::write(&p, "").unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(max_ts.is_none());
+        assert!(diag.is_empty());
+    }
+
+    #[test]
+    fn multi_record_returns_max_rewritten_ts() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(
+            dir.path(),
+            &[
+                r#"{"TimeCreated":"2026-01-15T09:01:00Z"}"#,
+                r#"{"TimeCreated":"2026-01-15T09:02:30Z"}"#,
+                r#"{"TimeCreated":"2026-01-15T09:02:00Z"}"#,
+            ],
+        );
+        let (max_ts, _) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(
+            max_ts.unwrap(),
+            Utc.with_ymd_and_hms(2026, 1, 15, 9, 2, 30).unwrap(),
+        );
+    }
+
+    #[test]
+    fn date_ms_rewrites_under_compression() {
+        // 30 real minutes → 14 logical days. The record's real ts is
+        // 75 s past `real_start`. Under compression, the rewritten
+        // value must land at `start_at + 75s * scale`.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[DATE_MS_LINE]);
+        let (max_ts, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        // Wire form must remain `\/Date(<new_ms>)\/`.
+        let s = std::fs::read_to_string(&p).unwrap();
+        assert!(s.contains(r"\/Date("), "DateMs wire form must survive: {s}");
+        // Sanity: max_ts is the rewritten ts of the only record.
+        assert!(max_ts.is_some());
+        assert_ne!(
+            max_ts.unwrap(),
+            Utc.with_ymd_and_hms(2026, 1, 15, 9, 1, 15).unwrap()
         );
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -78,6 +78,14 @@ impl TimeMap {
 
     /// Maps a real wall-clock timestamp onto the logical timeline.
     pub(crate) fn to_logical(&self, real: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        // Identity is a true pass-through: returning `real` directly
+        // preserves full sub-microsecond precision (chrono's
+        // `num_microseconds()` would otherwise truncate the nanosecond
+        // tail, breaking byte-identity round-trips for Falco's 9-digit
+        // and PS7's 7-digit fractional inputs).
+        if self.is_identity() {
+            return Ok(real);
+        }
         let delta_us = (real - self.real_generation_start)
             .num_microseconds()
             .context("real-to-generation delta exceeds microsecond range")?;
@@ -192,9 +200,7 @@ pub(crate) fn detect_overlaps(anchors: &[ExecAnchor]) -> Vec<OverlapWarning> {
 // Ground Truth (#63) rewrites by execution identity to guarantee
 // per-record provenance, not by window containment. This helper is
 // the entry point PCAP (#64) and JSONL (#65) rewriters consume —
-// they only have a raw timestamp, no execution identity. Locked-in
-// here per #63's "TimeMap + anchor list" deliverable so the later
-// sub-issues plug in without re-deriving the lookup rule.
+// they only have a raw timestamp, no execution identity.
 pub(crate) fn rewrite_ts(
     real_ts: DateTime<Utc>,
     time_map: &TimeMap,
@@ -210,11 +216,39 @@ pub(crate) fn rewrite_ts(
     }
 }
 
+/// Counters describing pass-through outcomes a JSONL rewrite pass
+/// produced. Returned as data so unit tests stay pure; the call site
+/// renders a per-file summary line via `eprintln!`.
+#[derive(Default)]
+pub(crate) struct RewriteDiagnostics {
+    pub(crate) malformed_lines: u64,
+    pub(crate) missing_field: u64,
+    pub(crate) unparseable_ts: u64,
+    pub(crate) out_of_window: u64,
+}
+
+impl RewriteDiagnostics {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.malformed_lines == 0
+            && self.missing_field == 0
+            && self.unparseable_ts == 0
+            && self.out_of_window == 0
+    }
+}
+
+/// Returns the inclusive `[start_at, start_at + logical_duration]`
+/// window the rewriter uses to flag out-of-window records.
+pub(crate) fn logical_window(time_map: &TimeMap) -> Result<(DateTime<Utc>, DateTime<Utc>)> {
+    let end = time_map
+        .start_at()
+        .checked_add_signed(Duration::microseconds(time_map.logical_us()))
+        .ok_or_else(|| anyhow!("logical window end overflows DateTime range"))?;
+    Ok((time_map.start_at(), end))
+}
+
 /// Returns the anchor whose window contains `ts`. Under overlapping
 /// windows, the deterministic pick is the one with the latest
 /// `real_start` not exceeding `ts`.
-//
-// Kept private; reachable only via `rewrite_ts`.
 fn find_anchor(anchors: &[ExecAnchor], ts: DateTime<Utc>) -> Option<&ExecAnchor> {
     anchors
         .iter()
@@ -291,6 +325,20 @@ mod tests {
         let tm = identity_map(start);
         let ts = fixed(1_737_000_120);
         assert_eq!(tm.to_logical(ts).unwrap(), ts);
+    }
+
+    #[test]
+    fn identity_map_preserves_sub_microsecond_precision() {
+        // Falco's 9-digit nanosecond and PS7's 7-digit 100 ns fractions
+        // would be truncated by `num_microseconds()`. The identity
+        // short-circuit must preserve them so JSONL rewriters can
+        // round-trip byte-for-byte under identity.
+        let start = fixed(1_737_000_000);
+        let tm = identity_map(start);
+        let ts = start + Duration::nanoseconds(123_456_789);
+        let mapped = tm.to_logical(ts).unwrap();
+        assert_eq!(mapped, ts);
+        assert_eq!(mapped.timestamp_subsec_nanos(), 123_456_789);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `falco::rewrite_timestamps` and `sysmon::rewrite_timestamps`, both returning `(Option<DateTime<Utc>>, RewriteDiagnostics)` and delegating to `time::rewrite_ts` so each record is anchored per-execution when its real timestamp falls inside an `ExecAnchor` window, otherwise rewritten via the global `TimeMap`. `assemble_bundle` iterates the `telemetry` triples after the GT rewrite, dispatches by `kind`, and aggregates the max rewritten timestamp into `actual_end` (skipping aggregation under identity runs, where the upstream pin must win).

Both rewriters use **in-place string substitution at the line/byte level** rather than parse-and-re-serialize. This is the only way to keep:

- Sysmon's PowerShell 5.1 wire form `\/Date(<ms>)\/` intact (the escaped slashes are literal wire bytes; serde would re-escape inconsistently). The bare `/Date(<ms>)/` spelling that some serde re-encoders emit after a parse round-trip is also accepted, and the input's escaping is preserved on write (escaped stays escaped; bare stays bare).
- Falco's non-RFC-3339 nanosecond form `…+0000` (offset without a colon — `chrono::DateTime::parse_from_rfc3339` rejects it; parsed via explicit `%z` format and re-emitted the same way).
- Sysmon's input offset/precision on ISO 8601 (a `+09:00` input is rewritten to `+09:00`, not normalized to `Z`; fractional digit count is preserved).

`TimeMap::to_logical` short-circuits when `is_identity()` and returns the input timestamp unchanged. Without this, `(real - real_generation_start).num_microseconds()` would truncate the sub-microsecond tail of full-precision inputs (Falco's 9-digit nanosecond form, PowerShell 7+ `.ToString("o")` 7-digit 100 ns ticks), breaking the byte-identity round-trip the issue requires under identity. Anchor-based rewrites already preserve nanoseconds because `chrono::Duration` subtraction/addition operates at nanosecond resolution.

Diagnostics are returned as data (mirroring #63's `OverlapWarning`); the call site in `assemble_bundle` prints at most one summary line per file when any counter is non-zero.

### Sysmon field cataloguing

`Get-WinEvent | ConvertTo-Json -Compress` emits other timestamp-looking fields inside `System` (e.g. `SystemTime` siblings) and inside `Message` for some event IDs. Per the issue, **initial rewrite scope is `TimeCreated` only** — that is the single field the validator consults via `parse_sysmon_timestamp_us` ([src/validator.rs:1478](https://github.com/aicers/multifold/blob/main/src/validator.rs)), and rewriting it covers the L4-002 correctness contract. Any other field that turns out to need rewriting can be lifted in a follow-up issue rather than expanding this PR's scope.

Closes #65
Part of #67

## Test plan

- [x] `cargo test` passes (Falco and Sysmon rewriter tests cover round-trip, anchor preservation, out-of-window fallback, pass-through edge cases, and aggregator contract)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` is clean
- [x] Falco identity round-trip is byte-identical for both observed `time` formats (`…+0000` nanosecond and `Z` second-precision), including a nonzero `.123456789+0000` fraction
- [x] Sysmon identity round-trip is byte-identical for `\/Date(ms)\/`, bare `/Date(ms)/`, ISO `Z`, ISO `+09:00`, ISO with 6-digit, 7-digit (.NET `o`), and 9-digit fractional inputs
- [x] Bare `/Date(ms)/` rewrites under compression keep their bare slashes (no promotion to the escaped spelling)
- [x] An anchor-window burst keeps its real inter-record spacing after rewrite and the first record lands at the anchor's `logical_start`
- [x] A record outside every anchor window is rewritten via the global `TimeMap`
- [x] Each pass-through failure mode (missing field, malformed JSON, unparseable timestamp, out-of-window) leaves the line unchanged and increments only the matching `RewriteDiagnostics` counter
- [x] Empty/all-passthrough files return `None`; multi-record files return the max rewritten timestamp
- [x] Sysmon ISO 8601 input with `+09:00` is rewritten to `+09:00`, not normalized to `Z`