### PR TITLE
Harden JSONL field locator robustness (#72)

### DIFF
--- a/src/falco.rs
+++ b/src/falco.rs
@@ -177,10 +177,11 @@ fn rewrite_falco_line(
     let rewritten = rewrite_ts(real_ts, time_map, anchors)?;
     let new_value = format_falco_time(rewritten, style, offset);
     let Some(new_body) = substitute_field_value(body, TIME_KEY, &new_value) else {
-        // Field is present per the JSON parse but not locatable by
-        // raw substring search — exotic whitespace inside the line.
-        // Treat as malformed and leave the line byte-identical rather
-        // than emitting an incorrect rewrite.
+        // Field is present per the JSON parse but not locatable by the
+        // depth-1 walker — duplicate top-level keys (last-write-wins is
+        // not a stable contract we lean on). Treat as malformed and
+        // leave the line byte-identical rather than emitting an
+        // incorrect rewrite.
         diag.malformed_lines += 1;
         return Ok(None);
     };
@@ -226,36 +227,188 @@ fn format_falco_time(utc: DateTime<Utc>, style: FalcoStyle, offset: FixedOffset)
     }
 }
 
-/// Replaces the string value of `field` in a compact JSON line with
-/// `new_value`, byte-for-byte, leaving every other byte intact.
+/// Replaces the string value of the depth-1 object key `field` in a
+/// JSON line with `new_value`, byte-for-byte. Every other byte of the
+/// input — including insignificant whitespace and any unrelated keys —
+/// is preserved exactly.
 ///
-/// Searches for the literal `"<field>":"`, then scans forward to the
-/// next unescaped `"` (respecting backslash escapes so wire-form
-/// `\/Date(…)\/` survives intact in Sysmon). Returns `None` when the
-/// pattern is not present.
+/// Uses a structural walker (not raw substring search) so:
+///   - JSON-permitted whitespace around `:` or around the string value
+///     (e.g. `"time" : "..."`) does not defeat the locator,
+///   - a `"<field>":"..."` substring embedded inside *another* field's
+///     string value is not mistaken for the real top-level key,
+///   - backslash escapes are respected so wire-form `\/Date(...)\/`
+///     survives intact in Sysmon.
+///
+/// Returns `None` when the field is not present as a depth-1
+/// string-valued key, or appears more than once at depth 1 (duplicate
+/// keys are treated as ambiguous and left to the caller's
+/// `malformed_lines` counter).
 pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) -> Option<String> {
-    let needle = format!("\"{field}\":\"");
-    let key_pos = raw.find(&needle)?;
-    let value_start = key_pos + needle.len();
+    let (val_start, val_end) = locate_field_value_range(raw, field)?;
+    let mut out = String::with_capacity(raw.len() + new_value.len());
+    out.push_str(raw.get(..val_start)?);
+    out.push_str(new_value);
+    out.push_str(raw.get(val_end..)?);
+    Some(out)
+}
 
+/// Returns the raw on-wire bytes (without unescaping) of the depth-1
+/// object key `field`'s string value. Required so Sysmon can recognize
+/// the PowerShell 5.1 `\/Date(<ms>)\/` form verbatim. Returns `None`
+/// under the same conditions as `substitute_field_value`.
+pub(super) fn locate_field_string_value<'a>(raw: &'a str, field: &str) -> Option<&'a str> {
+    let (start, end) = locate_field_value_range(raw, field)?;
+    raw.get(start..end)
+}
+
+/// Locates the byte range covering the string value of the depth-1
+/// object key `field`. The range covers the bytes *between* the
+/// surrounding quotes — neither quote is included. See
+/// `substitute_field_value` for the full robustness contract.
+fn locate_field_value_range(raw: &str, field: &str) -> Option<(usize, usize)> {
     let bytes = raw.as_bytes();
-    let mut end = value_start;
-    while end < bytes.len() {
-        match bytes.get(end)? {
-            b'\\' if end + 1 < bytes.len() => end += 2,
-            b'"' => break,
-            _ => end += 1,
-        }
+    let field_bytes = field.as_bytes();
+    let mut i = skip_ws(bytes, 0);
+    if bytes.get(i).copied() != Some(b'{') {
+        return None;
     }
-    if end >= bytes.len() {
+    i += 1;
+    i = skip_ws(bytes, i);
+    if bytes.get(i).copied() == Some(b'}') {
         return None;
     }
 
-    let mut out = String::with_capacity(raw.len() + new_value.len());
-    out.push_str(&raw[..value_start]);
-    out.push_str(new_value);
-    out.push_str(&raw[end..]);
-    Some(out)
+    let mut result: Option<(usize, usize)> = None;
+    let mut seen_count: usize = 0;
+
+    loop {
+        if bytes.get(i).copied() != Some(b'"') {
+            return None;
+        }
+        let key_start = i + 1;
+        let key_end = scan_string_end(bytes, key_start)?;
+        let key_matches = bytes.get(key_start..key_end) == Some(field_bytes);
+        i = key_end + 1;
+
+        i = skip_ws(bytes, i);
+        if bytes.get(i).copied() != Some(b':') {
+            return None;
+        }
+        i += 1;
+        i = skip_ws(bytes, i);
+
+        let value_byte = bytes.get(i).copied()?;
+        if value_byte == b'"' {
+            let val_start = i + 1;
+            let val_end = scan_string_end(bytes, val_start)?;
+            if key_matches {
+                seen_count += 1;
+                if seen_count > 1 {
+                    return None;
+                }
+                result = Some((val_start, val_end));
+            }
+            i = val_end + 1;
+        } else {
+            i = skip_value(bytes, i)?;
+            if key_matches {
+                seen_count += 1;
+                if seen_count > 1 {
+                    return None;
+                }
+                // Non-string value: nothing to substitute. `result`
+                // stays `None`; the caller distinguishes the
+                // "field-present-but-non-string" case via the parsed
+                // JSON value's type before invoking us.
+            }
+        }
+
+        i = skip_ws(bytes, i);
+        match bytes.get(i).copied()? {
+            b',' => {
+                i += 1;
+                i = skip_ws(bytes, i);
+            }
+            b'}' => return result,
+            _ => return None,
+        }
+    }
+}
+
+/// Advances past JSON insignificant whitespace (space, tab, CR, LF).
+/// Non-ASCII whitespace is intentionally not skipped — JSON does not
+/// recognize it as insignificant.
+fn skip_ws(bytes: &[u8], mut i: usize) -> usize {
+    while let Some(&c) = bytes.get(i) {
+        match c {
+            b' ' | b'\t' | b'\r' | b'\n' => i += 1,
+            _ => break,
+        }
+    }
+    i
+}
+
+/// Scans from `start` to the position of the closing `"` of a JSON
+/// string, respecting backslash escapes. Returns the index of the
+/// closing quote (not past it). Returns `None` on premature end.
+fn scan_string_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    while let Some(&c) = bytes.get(i) {
+        match c {
+            b'\\' => {
+                bytes.get(i + 1)?;
+                i += 2;
+            }
+            b'"' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Skips over a JSON value starting at `i`, returning the index of the
+/// byte one past the value. Handles strings, objects, arrays, and
+/// primitive tokens (number / `true` / `false` / `null`). Nested
+/// brace/bracket depth is tracked uniformly: well-formed JSON (which
+/// the caller has already validated via `serde_json::from_str`)
+/// guarantees that the next `}` or `]` at depth 1 closes the outer
+/// container.
+fn skip_value(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    match bytes.get(i).copied()? {
+        b'"' => Some(scan_string_end(bytes, i + 1)? + 1),
+        b'{' | b'[' => {
+            let mut depth: usize = 1;
+            i += 1;
+            while depth > 0 {
+                match bytes.get(i).copied()? {
+                    b'"' => {
+                        i = scan_string_end(bytes, i + 1)? + 1;
+                    }
+                    b'{' | b'[' => {
+                        depth += 1;
+                        i += 1;
+                    }
+                    b'}' | b']' => {
+                        depth -= 1;
+                        i += 1;
+                    }
+                    _ => i += 1,
+                }
+            }
+            Some(i)
+        }
+        _ => {
+            while let Some(&c) = bytes.get(i) {
+                match c {
+                    b',' | b'}' | b']' | b' ' | b'\t' | b'\r' | b'\n' => break,
+                    _ => i += 1,
+                }
+            }
+            Some(i)
+        }
+    }
 }
 
 /// Checks whether a container is currently running.
@@ -590,6 +743,76 @@ mod tests {
             max_ts.unwrap(),
             Utc.with_ymd_and_hms(2026, 1, 15, 9, 2, 30).unwrap(),
         );
+    }
+
+    // ── #72: robustness contract ──────────────────────────────────
+
+    #[test]
+    fn whitespace_around_colon_and_value_round_trips_byte_for_byte() {
+        // Valid JSON with insignificant whitespace around `:` and the
+        // string value must be rewritten correctly under identity and
+        // pass through byte-for-byte (no whitespace normalization, no
+        // diagnostic counter incremented).
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time" : "2026-01-15T09:01:00Z" , "rule":"r"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn embedded_time_substring_is_not_mistaken_for_real_key() {
+        // A prior field's string value literally contains `\"time\":`
+        // (i.e. the bytes `"time":` after JSON-unescaping). The
+        // structural walker must skip over it and only rewrite the
+        // real top-level `time`. The embedded substring must remain
+        // byte-for-byte unchanged.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let line = r#"{"output":"x \"time\":\"fake\" y","time":"2026-01-15T09:01:00Z"}"#;
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[line]);
+        let (_, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        let s = std::fs::read_to_string(&p).unwrap();
+        // The embedded substring survives literally.
+        assert!(
+            s.contains(r#"\"time\":\"fake\""#),
+            "embedded substring must survive byte-for-byte: {s}",
+        );
+        // The real `time` key was rewritten — its original value is
+        // gone, replaced by the logical-start anchor under compression.
+        assert!(
+            !s.contains("2026-01-15T09:01:00Z"),
+            "real top-level `time` should have been rewritten: {s}",
+        );
+    }
+
+    #[test]
+    fn non_string_time_value_counts_as_unparseable_ts() {
+        // `time` is present but its JSON value is a number, not a
+        // string. The contract classifies this as `unparseable_ts`,
+        // matching Sysmon's identical classification of the same shape.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":12345,"rule":"r"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.unparseable_ts, 1);
+        assert_eq!(diag.missing_field, 0);
+        assert_eq!(diag.malformed_lines, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
     }
 
     #[test]

--- a/src/falco.rs
+++ b/src/falco.rs
@@ -161,7 +161,23 @@ fn rewrite_falco_line(
         diag.malformed_lines += 1;
         return Ok(None);
     }
-    let raw_value = match locate_field(body, TIME_KEY) {
+    let (lookup, walker_total) = locate_field(body, TIME_KEY);
+    // Cross-check the structural walker's depth-1 key count against
+    // `serde_json`'s parsed Map size. They diverge precisely when one
+    // or more source keys collide after JSON-escape decoding (e.g. a
+    // literal `time` plus an escaped `time`); `serde_json` collapses
+    // them via last-write-wins while the byte-exact walker sees them as
+    // distinct keys. In that case the walker may have matched only the
+    // literal spelling, leaving any escaped duplicate untouched and the
+    // rewrite consistent with undefined-order semantics. The safe
+    // behavior is to refuse the rewrite and classify the line as
+    // malformed, matching the duplicate-key contract from #72.
+    let serde_total = parsed.as_object().expect("object check above").len();
+    if walker_total != serde_total {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    }
+    let raw_value = match lookup {
         FieldLookup::String { start, end } => body
             .get(start..end)
             .expect("walker returns an in-bounds range"),
@@ -276,7 +292,7 @@ pub(super) enum FieldLookup {
 /// the lookup result is `FieldLookup::String`. Any other outcome
 /// (`Absent`, `Duplicate`, `NonString`) returns `None`.
 pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) -> Option<String> {
-    let FieldLookup::String { start, end } = locate_field(raw, field) else {
+    let (FieldLookup::String { start, end }, _) = locate_field(raw, field) else {
         return None;
     };
     let mut out = String::with_capacity(raw.len() + new_value.len());
@@ -286,7 +302,9 @@ pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) ->
     Some(out)
 }
 
-/// Classifies a depth-1 object-key lookup of `field` in `raw`.
+/// Classifies a depth-1 object-key lookup of `field` in `raw`, along
+/// with the total number of depth-1 object members the walker
+/// iterated over.
 ///
 /// Uses a structural walker (not raw substring search) so:
 ///   - JSON-permitted whitespace around `:` or around the string value
@@ -303,46 +321,56 @@ pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) ->
 /// `"time"` for `time`) are not decoded and therefore do not
 /// match a literal `time` field. A stricter contract that decodes
 /// escape sequences in key strings is left to a future issue.
-pub(super) fn locate_field(raw: &str, field: &str) -> FieldLookup {
+///
+/// The returned key count enables callers to detect escape-equivalent
+/// duplicates that the byte-exact walker cannot see directly: comparing
+/// against `serde_json::Map::len()` flags collisions that `serde_json`
+/// merges via last-write-wins. The count is the number of completed
+/// key-value iterations; if the walker bails out mid-iteration on a
+/// structural error it is a partial count (the caller has already
+/// validated the JSON via `serde_json::from_str`, so this is only a
+/// soundness floor, not a contract).
+pub(super) fn locate_field(raw: &str, field: &str) -> (FieldLookup, usize) {
     let bytes = raw.as_bytes();
     let field_bytes = field.as_bytes();
     let mut i = skip_ws(bytes, 0);
     if bytes.get(i).copied() != Some(b'{') {
-        return FieldLookup::Absent;
+        return (FieldLookup::Absent, 0);
     }
     i += 1;
     i = skip_ws(bytes, i);
     if bytes.get(i).copied() == Some(b'}') {
-        return FieldLookup::Absent;
+        return (FieldLookup::Absent, 0);
     }
 
     let mut result = FieldLookup::Absent;
+    let mut total: usize = 0;
 
     loop {
         if bytes.get(i).copied() != Some(b'"') {
-            return FieldLookup::Absent;
+            return (FieldLookup::Absent, total);
         }
         let key_start = i + 1;
         let Some(key_end) = scan_string_end(bytes, key_start) else {
-            return FieldLookup::Absent;
+            return (FieldLookup::Absent, total);
         };
         let key_matches = bytes.get(key_start..key_end) == Some(field_bytes);
         i = key_end + 1;
 
         i = skip_ws(bytes, i);
         if bytes.get(i).copied() != Some(b':') {
-            return FieldLookup::Absent;
+            return (FieldLookup::Absent, total);
         }
         i += 1;
         i = skip_ws(bytes, i);
 
         let Some(value_byte) = bytes.get(i).copied() else {
-            return FieldLookup::Absent;
+            return (FieldLookup::Absent, total);
         };
         let (this_match, advance_to): (FieldLookup, usize) = if value_byte == b'"' {
             let val_start = i + 1;
             let Some(val_end) = scan_string_end(bytes, val_start) else {
-                return FieldLookup::Absent;
+                return (FieldLookup::Absent, total);
             };
             (
                 FieldLookup::String {
@@ -353,15 +381,17 @@ pub(super) fn locate_field(raw: &str, field: &str) -> FieldLookup {
             )
         } else {
             let Some(end) = skip_value(bytes, i) else {
-                return FieldLookup::Absent;
+                return (FieldLookup::Absent, total);
             };
             (FieldLookup::NonString, end)
         };
 
+        total += 1;
+
         if key_matches {
             match result {
                 FieldLookup::Absent => result = this_match,
-                _ => return FieldLookup::Duplicate,
+                _ => return (FieldLookup::Duplicate, total),
             }
         }
 
@@ -372,8 +402,8 @@ pub(super) fn locate_field(raw: &str, field: &str) -> FieldLookup {
                 i += 1;
                 i = skip_ws(bytes, i);
             }
-            Some(b'}') => return result,
-            _ => return FieldLookup::Absent,
+            Some(b'}') => return (result, total),
+            _ => return (FieldLookup::Absent, total),
         }
     }
 }
@@ -923,6 +953,49 @@ mod tests {
         let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
         assert_eq!(diag.malformed_lines, 1);
         assert_eq!(diag.unparseable_ts, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn literal_then_escaped_time_key_counts_as_malformed() {
+        // A literal `time` followed by an escape-equivalent
+        // `time` (which decodes to `time`). `serde_json` merges
+        // both into a single `time` entry via last-write-wins; the
+        // byte-exact walker sees only the literal as a match. Without
+        // the walker/serde key-count cross-check, the walker would
+        // rewrite the literal occurrence, leaving the escaped duplicate
+        // byte-identical, and the rewrite would be consistent with
+        // undefined-order semantics. The safe behavior is to refuse
+        // the rewrite and classify the line as `malformed_lines`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = "{\"time\":\"2026-01-15T09:01:00Z\",\"\\u0074ime\":\"2026-01-15T09:02:00Z\"}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn escaped_then_literal_time_key_counts_as_malformed() {
+        // Reverse order of `literal_then_escaped_time_key_counts_as_malformed`:
+        // the escaped spelling appears first, the literal `time`
+        // second. `serde_json` still merges both into a single `time`
+        // entry. The walker sees the literal as a match and would
+        // otherwise rewrite it; the cross-check must catch the
+        // collision and refuse.
+        let dir = tempfile::tempdir().unwrap();
+        let line = "{\"\\u0074ime\":\"2026-01-15T09:02:00Z\",\"time\":\"2026-01-15T09:01:00Z\"}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
         assert!(max_ts.is_none());
         assert_eq!(std::fs::read(&p).unwrap(), original);
     }

--- a/src/falco.rs
+++ b/src/falco.rs
@@ -161,15 +161,38 @@ fn rewrite_falco_line(
         diag.malformed_lines += 1;
         return Ok(None);
     }
-    let Some(time_value) = parsed.get(TIME_KEY) else {
-        diag.missing_field += 1;
-        return Ok(None);
+    let raw_value = match locate_field(body, TIME_KEY) {
+        FieldLookup::String { start, end } => body
+            .get(start..end)
+            .expect("walker returns an in-bounds range"),
+        FieldLookup::Absent => {
+            // serde may have seen the key under a JSON-escaped spelling
+            // (e.g. `"time"`), which the structural walker does
+            // not decode. Stricter handling of escaped key spellings is
+            // left to a future issue; the safe behavior here is to
+            // leave the line byte-identical and count as malformed.
+            if parsed.get(TIME_KEY).is_some() {
+                diag.malformed_lines += 1;
+            } else {
+                diag.missing_field += 1;
+            }
+            return Ok(None);
+        }
+        FieldLookup::Duplicate => {
+            // Duplicate top-level `time` keys: `serde_json`'s
+            // last-write-wins is not a stable contract to lean on.
+            // Detection happens here, before any type check, so the
+            // classification cannot flip depending on which duplicate
+            // survives the parse.
+            diag.malformed_lines += 1;
+            return Ok(None);
+        }
+        FieldLookup::NonString => {
+            diag.unparseable_ts += 1;
+            return Ok(None);
+        }
     };
-    let Some(time_str) = time_value.as_str() else {
-        diag.unparseable_ts += 1;
-        return Ok(None);
-    };
-    let Some((real_ts, style, offset)) = parse_falco_time(time_str) else {
+    let Some((real_ts, style, offset)) = parse_falco_time(raw_value) else {
         diag.unparseable_ts += 1;
         return Ok(None);
     };
@@ -177,11 +200,8 @@ fn rewrite_falco_line(
     let rewritten = rewrite_ts(real_ts, time_map, anchors)?;
     let new_value = format_falco_time(rewritten, style, offset);
     let Some(new_body) = substitute_field_value(body, TIME_KEY, &new_value) else {
-        // Field is present per the JSON parse but not locatable by the
-        // depth-1 walker — duplicate top-level keys (last-write-wins is
-        // not a stable contract we lean on). Treat as malformed and
-        // leave the line byte-identical rather than emitting an
-        // incorrect rewrite.
+        // The walker said `String` above; if substitution fails here
+        // something has changed under us. Leave the line byte-identical.
         diag.malformed_lines += 1;
         return Ok(None);
     };
@@ -227,10 +247,46 @@ fn format_falco_time(utc: DateTime<Utc>, style: FalcoStyle, offset: FixedOffset)
     }
 }
 
+/// Classification of a depth-1 object-key lookup. The structural walker
+/// distinguishes these four outcomes so each rewriter can map them to
+/// the right diagnostic counter without relying on `serde_json`'s
+/// last-write-wins behavior for duplicate keys.
+pub(super) enum FieldLookup {
+    /// Field not present as a depth-1 key (as seen by byte-level key
+    /// comparison — JSON-escaped key spellings are intentionally not
+    /// decoded; see `locate_field`).
+    Absent,
+    /// Field appears more than once at depth 1.
+    Duplicate,
+    /// Field present exactly once at depth 1, but its value is not a
+    /// JSON string.
+    NonString,
+    /// Field present exactly once at depth 1 with a string value. The
+    /// range covers the bytes *between* the surrounding quotes —
+    /// neither quote is included.
+    String { start: usize, end: usize },
+}
+
 /// Replaces the string value of the depth-1 object key `field` in a
 /// JSON line with `new_value`, byte-for-byte. Every other byte of the
 /// input — including insignificant whitespace and any unrelated keys —
 /// is preserved exactly.
+///
+/// Internally consults `locate_field`; substitution only happens when
+/// the lookup result is `FieldLookup::String`. Any other outcome
+/// (`Absent`, `Duplicate`, `NonString`) returns `None`.
+pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) -> Option<String> {
+    let FieldLookup::String { start, end } = locate_field(raw, field) else {
+        return None;
+    };
+    let mut out = String::with_capacity(raw.len() + new_value.len());
+    out.push_str(raw.get(..start)?);
+    out.push_str(new_value);
+    out.push_str(raw.get(end..)?);
+    Some(out)
+}
+
+/// Classifies a depth-1 object-key lookup of `field` in `raw`.
 ///
 /// Uses a structural walker (not raw substring search) so:
 ///   - JSON-permitted whitespace around `:` or around the string value
@@ -238,100 +294,86 @@ fn format_falco_time(utc: DateTime<Utc>, style: FalcoStyle, offset: FixedOffset)
 ///   - a `"<field>":"..."` substring embedded inside *another* field's
 ///     string value is not mistaken for the real top-level key,
 ///   - backslash escapes are respected so wire-form `\/Date(...)\/`
-///     survives intact in Sysmon.
+///     survives intact in Sysmon,
+///   - duplicate top-level occurrences of `field` are reported via
+///     `FieldLookup::Duplicate` rather than silently picking one
+///     occurrence the way `serde_json`'s last-write-wins would.
 ///
-/// Returns `None` when the field is not present as a depth-1
-/// string-valued key, or appears more than once at depth 1 (duplicate
-/// keys are treated as ambiguous and left to the caller's
-/// `malformed_lines` counter).
-pub(super) fn substitute_field_value(raw: &str, field: &str, new_value: &str) -> Option<String> {
-    let (val_start, val_end) = locate_field_value_range(raw, field)?;
-    let mut out = String::with_capacity(raw.len() + new_value.len());
-    out.push_str(raw.get(..val_start)?);
-    out.push_str(new_value);
-    out.push_str(raw.get(val_end..)?);
-    Some(out)
-}
-
-/// Returns the raw on-wire bytes (without unescaping) of the depth-1
-/// object key `field`'s string value. Required so Sysmon can recognize
-/// the PowerShell 5.1 `\/Date(<ms>)\/` form verbatim. Returns `None`
-/// under the same conditions as `substitute_field_value`.
-pub(super) fn locate_field_string_value<'a>(raw: &'a str, field: &str) -> Option<&'a str> {
-    let (start, end) = locate_field_value_range(raw, field)?;
-    raw.get(start..end)
-}
-
-/// Locates the byte range covering the string value of the depth-1
-/// object key `field`. The range covers the bytes *between* the
-/// surrounding quotes — neither quote is included. See
-/// `substitute_field_value` for the full robustness contract.
-fn locate_field_value_range(raw: &str, field: &str) -> Option<(usize, usize)> {
+/// Key comparison is byte-exact: JSON-escaped key spellings (e.g.
+/// `"time"` for `time`) are not decoded and therefore do not
+/// match a literal `time` field. A stricter contract that decodes
+/// escape sequences in key strings is left to a future issue.
+pub(super) fn locate_field(raw: &str, field: &str) -> FieldLookup {
     let bytes = raw.as_bytes();
     let field_bytes = field.as_bytes();
     let mut i = skip_ws(bytes, 0);
     if bytes.get(i).copied() != Some(b'{') {
-        return None;
+        return FieldLookup::Absent;
     }
     i += 1;
     i = skip_ws(bytes, i);
     if bytes.get(i).copied() == Some(b'}') {
-        return None;
+        return FieldLookup::Absent;
     }
 
-    let mut result: Option<(usize, usize)> = None;
-    let mut seen_count: usize = 0;
+    let mut result = FieldLookup::Absent;
 
     loop {
         if bytes.get(i).copied() != Some(b'"') {
-            return None;
+            return FieldLookup::Absent;
         }
         let key_start = i + 1;
-        let key_end = scan_string_end(bytes, key_start)?;
+        let Some(key_end) = scan_string_end(bytes, key_start) else {
+            return FieldLookup::Absent;
+        };
         let key_matches = bytes.get(key_start..key_end) == Some(field_bytes);
         i = key_end + 1;
 
         i = skip_ws(bytes, i);
         if bytes.get(i).copied() != Some(b':') {
-            return None;
+            return FieldLookup::Absent;
         }
         i += 1;
         i = skip_ws(bytes, i);
 
-        let value_byte = bytes.get(i).copied()?;
-        if value_byte == b'"' {
+        let Some(value_byte) = bytes.get(i).copied() else {
+            return FieldLookup::Absent;
+        };
+        let (this_match, advance_to): (FieldLookup, usize) = if value_byte == b'"' {
             let val_start = i + 1;
-            let val_end = scan_string_end(bytes, val_start)?;
-            if key_matches {
-                seen_count += 1;
-                if seen_count > 1 {
-                    return None;
-                }
-                result = Some((val_start, val_end));
-            }
-            i = val_end + 1;
+            let Some(val_end) = scan_string_end(bytes, val_start) else {
+                return FieldLookup::Absent;
+            };
+            (
+                FieldLookup::String {
+                    start: val_start,
+                    end: val_end,
+                },
+                val_end + 1,
+            )
         } else {
-            i = skip_value(bytes, i)?;
-            if key_matches {
-                seen_count += 1;
-                if seen_count > 1 {
-                    return None;
-                }
-                // Non-string value: nothing to substitute. `result`
-                // stays `None`; the caller distinguishes the
-                // "field-present-but-non-string" case via the parsed
-                // JSON value's type before invoking us.
+            let Some(end) = skip_value(bytes, i) else {
+                return FieldLookup::Absent;
+            };
+            (FieldLookup::NonString, end)
+        };
+
+        if key_matches {
+            match result {
+                FieldLookup::Absent => result = this_match,
+                _ => return FieldLookup::Duplicate,
             }
         }
 
+        i = advance_to;
         i = skip_ws(bytes, i);
-        match bytes.get(i).copied()? {
-            b',' => {
+        match bytes.get(i).copied() {
+            Some(b',') => {
                 i += 1;
                 i = skip_ws(bytes, i);
             }
-            b'}' => return result,
-            _ => return None,
+            Some(b'}') => return result,
+            _ => return FieldLookup::Absent,
         }
     }
 }
@@ -811,6 +853,100 @@ mod tests {
         assert_eq!(diag.unparseable_ts, 1);
         assert_eq!(diag.missing_field, 0);
         assert_eq!(diag.malformed_lines, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_keys_count_as_malformed_lines() {
+        // Two `time` keys at depth 1, both strings. `serde_json`'s
+        // last-write-wins masks the duplicate at the parsed-value
+        // level, but the structural walker must detect it and the line
+        // must be classified as `malformed_lines` per #72's safe
+        // duplicate-key contract.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":"2026-01-15T09:01:00Z","time":"2026-01-15T09:02:00Z"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_keys_string_then_non_string_count_as_malformed() {
+        // First `time` is a string, second is a number. `serde_json`
+        // last-write-wins surfaces the number, which without duplicate
+        // detection would mis-classify as `unparseable_ts`. The walker
+        // must catch the duplicate first.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":"2026-01-15T09:01:00Z","time":12345}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_keys_non_string_then_string_count_as_malformed() {
+        // First `time` is a number, second is a string. `serde_json`
+        // last-write-wins surfaces the string; the walker must still
+        // detect the duplicate and classify as `malformed_lines`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":12345,"time":"2026-01-15T09:01:00Z"}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_keys_both_non_string_count_as_malformed() {
+        // Both `time` values are numbers. Without duplicate detection
+        // before the type check, this would mis-classify as
+        // `unparseable_ts`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"time":12345,"time":67890}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn escaped_key_spelling_is_out_of_scope_and_counts_as_malformed() {
+        // `"time"` decodes to `time` per JSON's escape rules but
+        // the structural walker compares key bytes literally and does
+        // not decode them. The robustness contract leaves stricter
+        // escape-aware key handling to a future issue; the safe
+        // behavior here is to pass the line through byte-for-byte and
+        // count it as `malformed_lines`, never as a false rewrite of
+        // a different key.
+        let dir = tempfile::tempdir().unwrap();
+        // The key on the wire is literally `time` (the bytes
+        // `\`, `u`, `0`, `0`, `7`, `4`, `i`, `m`, `e`). JSON decodes
+        // this to the string `time`, so `serde_json` sees the field;
+        // the walker compares key bytes literally, so it does not.
+        let line = "{\"\\u0074ime\":\"2026-01-15T09:01:00Z\",\"rule\":\"r\"}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.missing_field, 0);
         assert!(max_ts.is_none());
         assert_eq!(std::fs::read(&p).unwrap(), original);
     }

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 
-use crate::falco::{locate_field_string_value, substitute_field_value};
+use crate::falco::{FieldLookup, locate_field, substitute_field_value};
 use crate::time::{ExecAnchor, RewriteDiagnostics, TimeMap, logical_window, rewrite_ts};
 use crate::vm::{self, ProvisionedVm};
 
@@ -189,24 +189,40 @@ fn rewrite_sysmon_line(
         diag.malformed_lines += 1;
         return Ok(None);
     }
-    let Some(time_value) = parsed.get(TIME_KEY) else {
-        diag.missing_field += 1;
-        return Ok(None);
-    };
-    if !time_value.is_string() {
-        // Field is present but not a string (number, bool, null,
-        // object, array). Matches Falco's classification of the same
-        // shape via `time_value.as_str()`.
-        diag.unparseable_ts += 1;
-        return Ok(None);
-    }
-    let Some(raw_value) = locate_field_string_value(body, TIME_KEY) else {
-        // Parsed JSON says the depth-1 string-valued field exists, but
-        // the structural locator could not pin it down. The only
-        // remaining cause under the contract is duplicate top-level
-        // keys (left to a future stricter contract per #72).
-        diag.malformed_lines += 1;
-        return Ok(None);
+    let raw_value = match locate_field(body, TIME_KEY) {
+        FieldLookup::String { start, end } => body
+            .get(start..end)
+            .expect("walker returns an in-bounds range"),
+        FieldLookup::Absent => {
+            // serde may have seen the key under a JSON-escaped spelling
+            // (e.g. `"TimeCreated"`), which the structural walker
+            // does not decode. Stricter handling of escaped key
+            // spellings is left to a future issue; the safe behavior
+            // here is to leave the line byte-identical and count as
+            // malformed.
+            if parsed.get(TIME_KEY).is_some() {
+                diag.malformed_lines += 1;
+            } else {
+                diag.missing_field += 1;
+            }
+            return Ok(None);
+        }
+        FieldLookup::Duplicate => {
+            // Duplicate top-level `TimeCreated`: `serde_json`'s
+            // last-write-wins is not a stable contract to lean on.
+            // Detection happens here, before any type check, so the
+            // classification cannot flip depending on which duplicate
+            // survives the parse.
+            diag.malformed_lines += 1;
+            return Ok(None);
+        }
+        FieldLookup::NonString => {
+            // Field present but not a string (number, bool, null,
+            // object, array). Matches Falco's classification of the
+            // same shape.
+            diag.unparseable_ts += 1;
+            return Ok(None);
+        }
     };
     let Some((real_ts, style)) = parse_sysmon_time(raw_value) else {
         diag.unparseable_ts += 1;
@@ -216,6 +232,8 @@ fn rewrite_sysmon_line(
     let rewritten = rewrite_ts(real_ts, time_map, anchors)?;
     let new_value = format_sysmon_time(rewritten, &style);
     let Some(new_body) = substitute_field_value(body, TIME_KEY, &new_value) else {
+        // The walker said `String` above; if substitution fails here
+        // something has changed under us. Leave the line byte-identical.
         diag.malformed_lines += 1;
         return Ok(None);
     };
@@ -711,6 +729,101 @@ mod tests {
         assert_eq!(diag.unparseable_ts, 1);
         assert_eq!(diag.missing_field, 0);
         assert_eq!(diag.malformed_lines, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_created_keys_count_as_malformed_lines() {
+        // Two depth-1 `TimeCreated` keys, both strings. `serde_json`'s
+        // last-write-wins masks the duplicate at the parsed-value
+        // level, but the structural walker must detect it and the line
+        // must be classified as `malformed_lines` per #72's safe
+        // duplicate-key contract.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15Z","TimeCreated":"2026-01-15T09:02:15Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_created_string_then_non_string_count_as_malformed() {
+        // First `TimeCreated` is a string, second is a number.
+        // `serde_json` last-write-wins surfaces the number, which
+        // without duplicate detection would mis-classify as
+        // `unparseable_ts`. The walker must catch the duplicate first.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":"2026-01-15T09:01:15Z","TimeCreated":12345,"Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_created_non_string_then_string_count_as_malformed() {
+        // First `TimeCreated` is a number, second is a string.
+        // `serde_json` last-write-wins surfaces the string; the walker
+        // must still detect the duplicate and classify as
+        // `malformed_lines`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":12345,"TimeCreated":"2026-01-15T09:01:15Z","Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn duplicate_time_created_both_non_string_count_as_malformed() {
+        // Both `TimeCreated` values are numbers. Without duplicate
+        // detection before the type check, this would mis-classify as
+        // `unparseable_ts`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":12345,"TimeCreated":67890,"Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn escaped_key_spelling_is_out_of_scope_and_counts_as_malformed() {
+        // `"TimeCreated"` decodes to `TimeCreated` per JSON's
+        // escape rules but the structural walker compares key bytes
+        // literally and does not decode them. The robustness contract
+        // leaves stricter escape-aware key handling to a future issue;
+        // the safe behavior here is to pass the line through
+        // byte-for-byte and count it as `malformed_lines`, never as a
+        // false rewrite of a different key.
+        let dir = tempfile::tempdir().unwrap();
+        // The key on the wire is literally `TimeCreated` (the `T`
+        // byte replaced by `T`). JSON decodes this to
+        // `TimeCreated`, so `serde_json` sees the field; the walker
+        // compares key bytes literally, so it does not.
+        let line = "{\"\\u0054imeCreated\":\"2026-01-15T09:01:15Z\",\"Id\":4688}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.missing_field, 0);
         assert!(max_ts.is_none());
         assert_eq!(std::fs::read(&p).unwrap(), original);
     }

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 
-use crate::falco::substitute_field_value;
+use crate::falco::{locate_field_string_value, substitute_field_value};
 use crate::time::{ExecAnchor, RewriteDiagnostics, TimeMap, logical_window, rewrite_ts};
 use crate::vm::{self, ProvisionedVm};
 
@@ -189,12 +189,23 @@ fn rewrite_sysmon_line(
         diag.malformed_lines += 1;
         return Ok(None);
     }
-    if parsed.get(TIME_KEY).is_none() {
+    let Some(time_value) = parsed.get(TIME_KEY) else {
         diag.missing_field += 1;
         return Ok(None);
+    };
+    if !time_value.is_string() {
+        // Field is present but not a string (number, bool, null,
+        // object, array). Matches Falco's classification of the same
+        // shape via `time_value.as_str()`.
+        diag.unparseable_ts += 1;
+        return Ok(None);
     }
-    let Some(raw_value) = locate_raw_value(body, TIME_KEY) else {
-        diag.missing_field += 1;
+    let Some(raw_value) = locate_field_string_value(body, TIME_KEY) else {
+        // Parsed JSON says the depth-1 string-valued field exists, but
+        // the structural locator could not pin it down. The only
+        // remaining cause under the contract is duplicate top-level
+        // keys (left to a future stricter contract per #72).
+        diag.malformed_lines += 1;
         return Ok(None);
     };
     let Some((real_ts, style)) = parse_sysmon_time(raw_value) else {
@@ -216,28 +227,6 @@ fn rewrite_sysmon_line(
         *max_ts = Some(rewritten);
     }
     Ok(Some(new_body))
-}
-
-/// Reads the raw on-wire bytes between the field's opening and closing
-/// quotes without unescaping. Required so the PowerShell 5.1 form
-/// `\/Date(<ms>)\/` is recognized verbatim.
-fn locate_raw_value<'a>(raw: &'a str, field: &str) -> Option<&'a str> {
-    let needle = format!("\"{field}\":\"");
-    let key_pos = raw.find(&needle)?;
-    let value_start = key_pos + needle.len();
-    let bytes = raw.as_bytes();
-    let mut end = value_start;
-    while end < bytes.len() {
-        match bytes.get(end)? {
-            b'\\' if end + 1 < bytes.len() => end += 2,
-            b'"' => break,
-            _ => end += 1,
-        }
-    }
-    if end >= bytes.len() {
-        return None;
-    }
-    Some(&raw[value_start..end])
 }
 
 enum SysmonStyle {
@@ -649,6 +638,81 @@ mod tests {
             max_ts.unwrap(),
             Utc.with_ymd_and_hms(2026, 1, 15, 9, 2, 30).unwrap(),
         );
+    }
+
+    // ── #72: robustness contract ──────────────────────────────────
+
+    #[test]
+    fn whitespace_around_colon_with_date_ms_round_trips_byte_for_byte() {
+        // Valid JSON with insignificant whitespace around `:`. The
+        // `\/Date(<ms>)\/` escaped-slash form must survive intact and
+        // the line must pass through byte-for-byte under identity with
+        // no diagnostic incremented.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated" : "\/Date(1768467675000)\/" , "Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert!(diag.is_empty());
+        assert!(max_ts.is_some());
+        let written = std::fs::read(&p).unwrap();
+        assert_eq!(written, original);
+        assert!(
+            std::str::from_utf8(&written).unwrap().contains(r"\/Date("),
+            "escaped slashes must survive: {}",
+            std::str::from_utf8(&written).unwrap(),
+        );
+    }
+
+    #[test]
+    fn embedded_time_created_substring_is_not_mistaken_for_real_key() {
+        // A prior field's string value literally contains
+        // `\"TimeCreated\":\"fake\"`. The structural walker must skip
+        // it and rewrite only the real top-level `TimeCreated`. The
+        // embedded substring must remain byte-for-byte unchanged.
+        let real_start = Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap();
+        let logical_start = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let tm = TimeMap::new(
+            logical_start,
+            real_start,
+            Duration::try_minutes(30).unwrap(),
+            Duration::try_days(14).unwrap(),
+        )
+        .unwrap();
+        let line = r#"{"Message":"x \"TimeCreated\":\"fake\" y","TimeCreated":"2026-01-15T09:01:15Z","Id":4688}"#;
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_lines(dir.path(), &[line]);
+        let (_, diag) = rewrite_timestamps(&p, &tm, &[]).unwrap();
+        assert!(diag.is_empty());
+        let s = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            s.contains(r#"\"TimeCreated\":\"fake\""#),
+            "embedded substring must survive byte-for-byte: {s}",
+        );
+        // The real top-level `TimeCreated` was rewritten — its
+        // original ISO string is gone.
+        assert!(
+            !s.contains("\"TimeCreated\":\"2026-01-15T09:01:15Z\""),
+            "real top-level TimeCreated should have been rewritten: {s}",
+        );
+    }
+
+    #[test]
+    fn non_string_time_value_counts_as_unparseable_ts() {
+        // Per #72: a `TimeCreated` field present but with a non-string
+        // value (here, a number) must be classified as
+        // `unparseable_ts`, not `missing_field`. This matches Falco's
+        // classification of the same shape.
+        let dir = tempfile::tempdir().unwrap();
+        let line = r#"{"TimeCreated":12345,"Id":4688}"#;
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.unparseable_ts, 1);
+        assert_eq!(diag.missing_field, 0);
+        assert_eq!(diag.malformed_lines, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
     }
 
     #[test]

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -189,7 +189,24 @@ fn rewrite_sysmon_line(
         diag.malformed_lines += 1;
         return Ok(None);
     }
-    let raw_value = match locate_field(body, TIME_KEY) {
+    let (lookup, walker_total) = locate_field(body, TIME_KEY);
+    // Cross-check the structural walker's depth-1 key count against
+    // `serde_json`'s parsed Map size. They diverge precisely when one
+    // or more source keys collide after JSON-escape decoding (e.g. a
+    // literal `TimeCreated` plus an escaped `TimeCreated`);
+    // `serde_json` collapses them via last-write-wins while the
+    // byte-exact walker sees them as distinct keys. In that case the
+    // walker may have matched only the literal spelling, leaving any
+    // escaped duplicate untouched and the rewrite consistent with
+    // undefined-order semantics. The safe behavior is to refuse the
+    // rewrite and classify the line as malformed, matching the
+    // duplicate-key contract from #72.
+    let serde_total = parsed.as_object().expect("object check above").len();
+    if walker_total != serde_total {
+        diag.malformed_lines += 1;
+        return Ok(None);
+    }
+    let raw_value = match lookup {
         FieldLookup::String { start, end } => body
             .get(start..end)
             .expect("walker returns an in-bounds range"),
@@ -800,6 +817,49 @@ mod tests {
         let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
         assert_eq!(diag.malformed_lines, 1);
         assert_eq!(diag.unparseable_ts, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn literal_then_escaped_time_created_key_counts_as_malformed() {
+        // A literal `TimeCreated` followed by an escape-equivalent
+        // `TimeCreated` (which decodes to `TimeCreated`).
+        // `serde_json` merges both into a single `TimeCreated` entry
+        // via last-write-wins; the byte-exact walker sees only the
+        // literal as a match. Without the walker/serde key-count
+        // cross-check, the walker would rewrite the literal occurrence,
+        // leaving the escaped duplicate byte-identical, and the
+        // rewrite would be consistent with undefined-order semantics.
+        // The safe behavior is to refuse the rewrite and classify the
+        // line as `malformed_lines`.
+        let dir = tempfile::tempdir().unwrap();
+        let line = "{\"TimeCreated\":\"2026-01-15T09:01:15Z\",\"\\u0054imeCreated\":\"2026-01-15T09:02:15Z\",\"Id\":4688}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
+        assert!(max_ts.is_none());
+        assert_eq!(std::fs::read(&p).unwrap(), original);
+    }
+
+    #[test]
+    fn escaped_then_literal_time_created_key_counts_as_malformed() {
+        // Reverse order: the escaped spelling appears first, the
+        // literal `TimeCreated` second. `serde_json` still merges both
+        // into a single `TimeCreated` entry. The walker sees the
+        // literal as a match and would otherwise rewrite it; the
+        // cross-check must catch the collision and refuse.
+        let dir = tempfile::tempdir().unwrap();
+        let line = "{\"\\u0054imeCreated\":\"2026-01-15T09:02:15Z\",\"TimeCreated\":\"2026-01-15T09:01:15Z\",\"Id\":4688}";
+        let p = write_lines(dir.path(), &[line]);
+        let original = std::fs::read(&p).unwrap();
+        let (max_ts, diag) = rewrite_timestamps(&p, &identity_map(), &[]).unwrap();
+        assert_eq!(diag.malformed_lines, 1);
+        assert_eq!(diag.unparseable_ts, 0);
+        assert_eq!(diag.missing_field, 0);
         assert!(max_ts.is_none());
         assert_eq!(std::fs::read(&p).unwrap(), original);
     }


### PR DESCRIPTION
## Summary

Replaces the raw `str::find("\"<field>\":\"")` substring locator used by the Falco/Sysmon JSONL rewriters with a structural depth-1 object-key walker, closing the two robustness gaps called out in #72:

- JSON-permitted whitespace around `:` or around the string value (e.g. `{"time" : "..."}`) no longer defeats the locator. Such lines are valid JSON, `serde_json` parses them, and the rewriter now rewrites them correctly instead of misclassifying as `malformed_lines` (Falco) or `missing_field` (Sysmon).
- A `"<field>":"..."` substring embedded inside another field's string value is no longer mistaken for the real top-level key. The walker respects backslash escapes inside strings and only matches keys at depth 1.

Sysmon's `\/Date(<ms>)\/` escape form survives byte-for-byte.

Sysmon's classification of a non-string `TimeCreated` value (number, bool, null, object, array) is corrected from `missing_field` to `unparseable_ts`, matching Falco's behavior on the same shape.

### Duplicate top-level keys

Duplicate detection happens in the structural walker *before* any type check, so the classification cannot flip based on which value `serde_json`'s last-write-wins surfaces. All four shapes — `string/string`, `string/non-string`, `non-string/string`, `non-string/non-string` — are classified as `malformed_lines` consistently. A stricter duplicate-key contract is left to a future issue (per the issue's "Out of scope").

### Escape-equivalent duplicate keys

The structural walker compares depth-1 keys byte-exactly and does not decode JSON escape sequences in object keys. To avoid a partial rewrite when a line contains both a literal spelling (e.g. `time`) and an escape-equivalent spelling (e.g. `time`) of the same key — which `serde_json` merges via last-write-wins — the rewriter additionally cross-checks the walker's depth-1 key count against `serde_json::Map::len()`. Any mismatch indicates a hidden collision after JSON-escape decoding, and the line is classified as `malformed_lines` and passes through byte-for-byte rather than partially rewriting one occurrence. This covers both literal-then-escaped and escaped-then-literal orderings, with either string or non-string values.

### Escaped key spellings (out of scope)

The walker compares key bytes literally and does not decode JSON escape sequences in object keys. A line like `{"time":"..."}` parses successfully under `serde_json` (which decodes the key to `time`), but the structural walker does not match it. The safe behavior is to leave the line byte-identical and count as `malformed_lines` rather than emit a false rewrite of the wrong field. A stricter escape-aware key contract is left to a future issue.

### Locator API

The locator lives in `falco.rs` and exposes:

- `FieldLookup` — `Absent | Duplicate | NonString | String { start, end }`.
- `locate_field` — the structural walker; returns `(FieldLookup, usize)` where the usize is the count of depth-1 object members walked, used by the rewriters for the escape-equivalent duplicate cross-check.
- `substitute_field_value` — write-side helper that re-runs `locate_field` and replaces the string value.

Closes #72

## Test plan

- [x] Falco: valid JSON with whitespace around `:` and around the string value round-trips byte-for-byte under identity with no diagnostic incremented (`whitespace_around_colon_and_value_round_trips_byte_for_byte`).
- [x] Sysmon: same shape with `TimeCreated` and a `\/Date(<ms>)\/` value round-trips with escaped slashes intact (`whitespace_around_colon_with_date_ms_round_trips_byte_for_byte`).
- [x] Falco: a line whose earlier field's string value embeds `\"time\":\"fake\"` is not confused — only the real top-level `time` is rewritten, and the embedded substring survives byte-for-byte (`embedded_time_substring_is_not_mistaken_for_real_key`).
- [x] Sysmon: same embedded-substring guard for `TimeCreated` (`embedded_time_created_substring_is_not_mistaken_for_real_key`).
- [x] Sysmon: `{"TimeCreated":12345,"Id":4688}` increments `unparseable_ts` (not `missing_field`), passes through unchanged, and matches Falco's classification of the same shape (`non_string_time_value_counts_as_unparseable_ts` on both modules).
- [x] Duplicate top-level keys are classified as `malformed_lines` regardless of value-type ordering, on both modules (`duplicate_time_keys_count_as_malformed_lines`, `duplicate_time_keys_string_then_non_string_count_as_malformed`, `duplicate_time_keys_non_string_then_string_count_as_malformed`, `duplicate_time_keys_both_non_string_count_as_malformed`, and the `duplicate_time_created_*` counterparts).
- [x] Mixed literal-and-escaped duplicate keys (e.g. `{"time":"...","time":"..."}`) are classified as `malformed_lines`, in both orderings, on both modules (`literal_then_escaped_time_key_counts_as_malformed`, `escaped_then_literal_time_key_counts_as_malformed`, and the `*_time_created_*` counterparts).
- [x] Escaped key spellings (`{"time":"..."}`) are out of scope: the line passes through byte-for-byte and is counted as `malformed_lines`, on both modules (`escaped_key_spelling_is_out_of_scope_and_counts_as_malformed`).
- [x] All existing compact-JSON tests continue to pass (`cargo test falco`, `cargo test sysmon`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.