### PR TITLE
Document Falco/Sysmon timestamp rewriter scope (#74)

### DIFF
--- a/src/falco.rs
+++ b/src/falco.rs
@@ -90,6 +90,17 @@ pub(crate) async fn collect_logs(
 /// (or `None` when no record was rewritten) and a diagnostic counter
 /// the call site renders into a per-file warning line.
 ///
+/// Falco JSONL is treated as having a single rewritten timestamp field,
+/// `time`. This matches the validator's `FALCO_REQUIRED_FIELDS` in
+/// `src/validator.rs`, where `time` is the only timestamp-bearing entry
+/// consumed downstream (via the L2-009 required-field check; Falco has
+/// no L4 cross-source check at present). If a future Falco version or
+/// rule set introduces additional timestamp fields that downstream
+/// consumers care about, extend this rewriter and revisit the
+/// validator's Falco checks accordingly. See
+/// `sysmon::rewrite_timestamps` for the analogous `TimeCreated`-only
+/// scope statement on the Sysmon side.
+///
 /// Malformed lines, records missing the `time` field, and unparseable
 /// timestamp values pass through unchanged with their respective
 /// counters incremented. Records whose rewritten timestamp lands

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -139,15 +139,17 @@ pub(crate) async fn collect_logs(vm_host: &ProvisionedVm, output_dir: &Path) -> 
 /// offset and fractional precision on round-trip.
 ///
 /// Sysmon JSONL is treated as having a single rewritten timestamp
-/// field, `TimeCreated`. This is the only timestamp-bearing entry
-/// emitted by the `Get-WinEvent | ConvertTo-Json -Compress` capture
-/// path used in `collect_logs`, and matches the field consumed by the
-/// validator's L4-002 process↔Sysmon overlap check in
-/// `src/validator.rs`. If a future Sysmon schema or capture variant
-/// introduces additional timestamp fields that downstream consumers
-/// care about, extend this rewriter and revisit the validator
-/// accordingly. See `falco::rewrite_timestamps` for the analogous
-/// `time`-only scope statement on the Falco side.
+/// field, `TimeCreated`. This is the only Sysmon timestamp field the
+/// validator consumes today (via the L4-002 process↔Sysmon overlap
+/// check in `src/validator.rs`), so it is also the only one rewritten
+/// here. Other timestamp-looking fields observed in the
+/// `Get-WinEvent | ConvertTo-Json -Compress` capture path used by
+/// `collect_logs` — for example `SystemTime` siblings inside the
+/// `System` block and per-event-ID timestamps embedded in `Message` —
+/// are intentionally left untouched because no downstream consumer
+/// depends on them; if that changes, extend this rewriter and revisit
+/// the validator accordingly. See `falco::rewrite_timestamps` for the
+/// analogous `time`-only scope statement on the Falco side.
 pub(crate) fn rewrite_timestamps(
     path: &Path,
     time_map: &TimeMap,

--- a/src/sysmon.rs
+++ b/src/sysmon.rs
@@ -137,6 +137,17 @@ pub(crate) async fn collect_logs(vm_host: &ProvisionedVm, output_dir: &Path) -> 
 /// dual wire format (`\/Date(<ms>)\/` for Windows PowerShell 5.1, ISO
 /// 8601 for PowerShell 7+) and the requirement to preserve the input
 /// offset and fractional precision on round-trip.
+///
+/// Sysmon JSONL is treated as having a single rewritten timestamp
+/// field, `TimeCreated`. This is the only timestamp-bearing entry
+/// emitted by the `Get-WinEvent | ConvertTo-Json -Compress` capture
+/// path used in `collect_logs`, and matches the field consumed by the
+/// validator's L4-002 process↔Sysmon overlap check in
+/// `src/validator.rs`. If a future Sysmon schema or capture variant
+/// introduces additional timestamp fields that downstream consumers
+/// care about, extend this rewriter and revisit the validator
+/// accordingly. See `falco::rewrite_timestamps` for the analogous
+/// `time`-only scope statement on the Falco side.
 pub(crate) fn rewrite_timestamps(
     path: &Path,
     time_map: &TimeMap,


### PR DESCRIPTION
## Summary

Adds module-level doc comments to `falco::rewrite_timestamps` and `sysmon::rewrite_timestamps` describing the single timestamp field each rewriter touches (`time` for Falco, `TimeCreated` for Sysmon), the validator check that backs the scope, and a cross-reference linking the two modules.

The wording is deliberately conservative — it documents the *current* rewriter scope and validator alignment rather than asserting that no other timestamp fields can ever appear in sidecar output. No runtime behaviour changes; existing tests already pin these as the only rewritten fields.

Closes #74
Part of #67

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (no test changes; docs only)
- [x] Confirm `src/falco.rs` `rewrite_timestamps` doc comment names `time` and references `FALCO_REQUIRED_FIELDS` / `src/validator.rs`
- [x] Confirm `src/sysmon.rs` `rewrite_timestamps` doc comment names `TimeCreated` and references the L4-002 process↔Sysmon overlap check
- [x] Confirm both doc comments cross-reference each other