### PR TITLE
Add compressed AC-0 scenario and CI coverage (#66)

### DIFF
--- a/.github/scripts/check_ac0_compressed_gt.py
+++ b/.github/scripts/check_ac0_compressed_gt.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Assert ground_truth/manifest.jsonl invariants for the compressed AC-0 bundle.
+
+Checks (per issue #66, §3):
+
+* Exactly two execution records exist (one normal + one attack).
+* The two `start` timestamps land roughly `5d` and `10d` past `start_at`,
+  allowing a few seconds of logical-time slack for command-execution
+  overhead at the scheduler.
+* The inter-session gap between the two starts is approximately `5d`.
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+START_AT = "2026-05-03T00:00:00Z"
+OFFSET_NORMAL = timedelta(days=5)
+OFFSET_ATTACK = timedelta(days=10)
+EXPECTED_GAP = timedelta(days=5)
+
+# Logical-time slack: a few seconds of intra-window command execution plus
+# the scheduler's real-time jitter (mapped through scale_factor = 4032 it
+# can amount to several minutes of logical time, but realistic runs stay
+# within a few logical seconds because anchor windows preserve real
+# spacing). 10 minutes is generous and keeps CI green on slow runners.
+TOLERANCE = timedelta(minutes=10)
+
+
+def parse_z(s: str) -> datetime:
+    if not s.endswith("Z"):
+        raise ValueError(f"timestamp '{s}' must end with 'Z'")
+    return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def main(path: str) -> int:
+    with open(path, "r", encoding="utf-8") as fh:
+        records = [json.loads(line) for line in fh if line.strip()]
+
+    if len(records) != 2:
+        print(
+            f"FAIL: expected 2 records in manifest.jsonl, found {len(records)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    records.sort(key=lambda r: r["start"])
+    start_at = parse_z(START_AT)
+    first_start = parse_z(records[0]["start"])
+    second_start = parse_z(records[1]["start"])
+
+    first_offset = first_start - start_at
+    second_offset = second_start - start_at
+    if abs(first_offset - OFFSET_NORMAL) > TOLERANCE:
+        print(
+            f"FAIL: first record start offset = {first_offset} "
+            f"(expected ~{OFFSET_NORMAL}, tolerance {TOLERANCE})",
+            file=sys.stderr,
+        )
+        return 1
+    if abs(second_offset - OFFSET_ATTACK) > TOLERANCE:
+        print(
+            f"FAIL: second record start offset = {second_offset} "
+            f"(expected ~{OFFSET_ATTACK}, tolerance {TOLERANCE})",
+            file=sys.stderr,
+        )
+        return 1
+
+    gap = second_start - first_start
+    if abs(gap - EXPECTED_GAP) > TOLERANCE:
+        print(
+            f"FAIL: inter-session gap = {gap} (expected ~{EXPECTED_GAP}, "
+            f"tolerance {TOLERANCE})",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("manifest.jsonl invariants OK")
+    print(f"  first start  = {records[0]['start']} (offset {first_offset})")
+    print(f"  second start = {records[1]['start']} (offset {second_offset})")
+    print(f"  gap          = {gap}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/.github/scripts/check_ac0_compressed_meta.py
+++ b/.github/scripts/check_ac0_compressed_meta.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Assert meta.json invariants for the compressed AC-0 CI bundle.
+
+Checks:
+* `duration.actual_start == "2026-05-03T00:00:00Z"`
+* `duration.total == "14d"`
+* `actual_end > actual_start` and `actual_end <= start_at + 14d`
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+EXPECTED_START_AT = "2026-05-03T00:00:00Z"
+EXPECTED_TOTAL = "14d"
+LOGICAL_DURATION = timedelta(days=14)
+
+
+def parse_z(s: str) -> datetime:
+    if not s.endswith("Z"):
+        raise ValueError(f"timestamp '{s}' must end with 'Z'")
+    return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def main(path: str) -> int:
+    with open(path, "r", encoding="utf-8") as fh:
+        meta = json.load(fh)
+
+    duration = meta["duration"]
+    actual_start = duration["actual_start"]
+    actual_end = duration["actual_end"]
+    total = duration["total"]
+
+    if actual_start != EXPECTED_START_AT:
+        print(
+            f"FAIL: duration.actual_start = {actual_start!r}, expected {EXPECTED_START_AT!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if total != EXPECTED_TOTAL:
+        print(
+            f"FAIL: duration.total = {total!r}, expected {EXPECTED_TOTAL!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    start_dt = parse_z(actual_start)
+    end_dt = parse_z(actual_end)
+    upper = start_dt + LOGICAL_DURATION
+
+    if not end_dt > start_dt:
+        print(
+            f"FAIL: actual_end ({actual_end}) is not strictly after "
+            f"actual_start ({actual_start})",
+            file=sys.stderr,
+        )
+        return 1
+
+    if end_dt > upper:
+        print(
+            f"FAIL: actual_end ({actual_end}) exceeds start_at + 14d "
+            f"({upper.strftime('%Y-%m-%dT%H:%M:%SZ')})",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("meta.json invariants OK")
+    print(f"  actual_start = {actual_start}")
+    print(f"  total        = {total}")
+    print(f"  actual_end   = {actual_end}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/.github/scripts/check_ac0_compressed_pcap.py
+++ b/.github/scripts/check_ac0_compressed_pcap.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Assert PCAP structural invariants for the compressed AC-0 bundle.
+
+Checks (per issue #66, §3):
+
+* Magic byte is a recognised microsecond-resolution PCAP magic.
+* Packet count is strictly greater than zero.
+* Every per-packet timestamp falls in `[start_at, +∞)` (no negative
+  offsets relative to the scenario's logical start_at).
+* Packet timestamps are monotonically non-decreasing.
+
+Intra-packet interval preservation is *not* asserted here — that is
+unit-test territory.
+"""
+
+import struct
+import sys
+from datetime import datetime, timedelta, timezone
+
+START_AT = datetime.fromisoformat("2026-05-03T00:00:00+00:00").astimezone(timezone.utc)
+PCAP_MAGIC_US_LE = b"\xd4\xc3\xb2\xa1"
+PCAP_MAGIC_US_BE = b"\xa1\xb2\xc3\xd4"
+
+
+def main(path: str) -> int:
+    with open(path, "rb") as fh:
+        data = fh.read()
+
+    if len(data) < 24:
+        print(f"FAIL: pcap '{path}' shorter than global header", file=sys.stderr)
+        return 1
+
+    magic = data[0:4]
+    if magic == PCAP_MAGIC_US_LE:
+        endian = "<"
+    elif magic == PCAP_MAGIC_US_BE:
+        endian = ">"
+    else:
+        print(
+            f"FAIL: unrecognised pcap magic {magic.hex()} "
+            f"(expected microsecond LE or BE)",
+            file=sys.stderr,
+        )
+        return 1
+
+    offset = 24
+    count = 0
+    last_ts: datetime | None = None
+    while offset < len(data):
+        if offset + 16 > len(data):
+            print(
+                f"FAIL: truncated packet record at offset {offset}",
+                file=sys.stderr,
+            )
+            return 1
+        ts_sec, ts_usec, incl_len, _orig_len = struct.unpack(
+            f"{endian}IIII", data[offset : offset + 16]
+        )
+        if ts_usec >= 1_000_000:
+            print(
+                f"FAIL: packet {count} has out-of-range microseconds: {ts_usec}",
+                file=sys.stderr,
+            )
+            return 1
+        ts = datetime.fromtimestamp(0, tz=timezone.utc) + timedelta(
+            seconds=ts_sec, microseconds=ts_usec
+        )
+        if ts < START_AT:
+            print(
+                f"FAIL: packet {count} timestamp {ts.isoformat()} is before "
+                f"start_at {START_AT.isoformat()}",
+                file=sys.stderr,
+            )
+            return 1
+        if last_ts is not None and ts < last_ts:
+            print(
+                f"FAIL: packet {count} timestamp {ts.isoformat()} regresses "
+                f"after previous {last_ts.isoformat()}",
+                file=sys.stderr,
+            )
+            return 1
+        last_ts = ts
+        count += 1
+        offset += 16 + incl_len
+
+    if count == 0:
+        print("FAIL: pcap has zero packets", file=sys.stderr)
+        return 1
+
+    print(f"pcap structural invariants OK ({count} packets)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,38 @@ jobs:
       - name: Validate AC-0 bundle
         run: cargo run --release -- validate -b ac0-bundle
 
+  ac0-compressed-pipeline:
+    name: AC-0 Compressed Pipeline
+    needs: [check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Generate AC-0 compressed bundle
+        run: cargo run --release -- generate -s scenarios/ac-0-compressed.scenario.yaml -o ac0c-bundle
+
+      - name: Validate AC-0 compressed bundle
+        run: cargo run --release -- validate -b ac0c-bundle
+
+      - name: Assert meta.json invariants
+        run: python3 .github/scripts/check_ac0_compressed_meta.py ac0c-bundle/meta.json
+
+      - name: Assert ground_truth manifest invariants
+        run: python3 .github/scripts/check_ac0_compressed_gt.py ac0c-bundle/ground_truth/manifest.jsonl
+
+      - name: Assert pcap structural invariants
+        run: python3 .github/scripts/check_ac0_compressed_pcap.py ac0c-bundle/net/lan.pcap
+
   docker-e2e:
     name: Docker E2E
     needs: [check]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .claude/
 .vscode/
 tmp/
+__pycache__/

--- a/scenarios/ac-0-compressed.scenario.yaml
+++ b/scenarios/ac-0-compressed.scenario.yaml
@@ -1,0 +1,63 @@
+version: "1"
+
+metadata:
+  name: ac-0-compressed
+  description: >-
+    Compressed variant of ac-0 used to demonstrate end-to-end
+    time-compression in CI: same infrastructure and commands, but
+    fixed start_at and a 14d logical_duration over a 5m real
+    duration (scale_factor = 4032). The two activities are spaced
+    5d / 10d apart in logical time to keep anchor windows overlap
+    free even on slow CI runners.
+
+environment:
+  scale: minimal
+  encryption: none
+  workload: light
+  threat: single
+  attacker: scripted
+
+start_at: "2026-05-03T00:00:00Z"
+duration: 5m
+logical_duration: 14d
+
+infrastructure:
+  hosts:
+    - name: attacker-001
+      os: linux
+      role: attacker
+      image: alpine:3.19
+    - name: target-001
+      os: linux
+      role: target
+      image: alpine:3.19
+      setup:
+        - "while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 3\\r\\n\\r\\nok\\n' | nc -l -p 80 > /dev/null; done &"
+  network:
+    segments:
+      - name: lan
+        subnet: 10.101.0.0/24
+        hosts:
+          - attacker-001
+          - target-001
+
+activities:
+  normal:
+    - name: http-health-check
+      source: attacker-001
+      target: target-001
+      command: "curl -s http://${target_ip}:80/"
+      protocol: tcp
+      dst_port: 80
+      start_offset: 5d
+  attack:
+    - name: nmap-port-scan
+      source: attacker-001
+      target: target-001
+      command: "nmap -sS -p 80 ${target_ip}"
+      protocol: tcp
+      dst_port: 80
+      technique: T1046
+      phase: reconnaissance
+      tool: nmap
+      start_offset: 10d

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -487,4 +487,122 @@ mod tests {
         .unwrap();
         assert_eq!(meta.duration.actual_end, meta.duration.actual_start);
     }
+
+    /// Loads the compressed AC-0 scenario together with the canonical
+    /// non-identity inputs the meta tests need:
+    ///
+    /// * `start` — the run's `real_generation_start` (`Utc::now()` stand-in).
+    /// * `logical_start` — the scenario's declared `start_at`.
+    fn ac0_compressed_test_inputs() -> (Scenario, HostIps, DateTime<Utc>, DateTime<Utc>) {
+        let yaml = include_str!("../scenarios/ac-0-compressed.scenario.yaml");
+        let scenario: Scenario = serde_yaml::from_str(yaml).unwrap();
+        let host_ips = vec![
+            (
+                "attacker-001".to_owned(),
+                vec![Ipv4Addr::new(10, 101, 0, 2)],
+            ),
+            ("target-001".to_owned(), vec![Ipv4Addr::new(10, 101, 0, 3)]),
+        ];
+        let start = DateTime::parse_from_rfc3339("2026-01-15T09:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let logical_start = scenario.start_at.unwrap();
+        (scenario, host_ips, start, logical_start)
+    }
+
+    fn ac0_compressed_time_map(
+        scenario: &Scenario,
+        real_generation_start: DateTime<Utc>,
+        logical_start: DateTime<Utc>,
+    ) -> TimeMap {
+        let real_duration = parse_duration(&scenario.duration).unwrap();
+        let logical_duration =
+            parse_duration(scenario.logical_duration.as_deref().unwrap()).unwrap();
+        TimeMap::new(
+            logical_start,
+            real_generation_start,
+            real_duration,
+            logical_duration,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn build_meta_compressed_generated_at_is_real_not_logical() {
+        let (scenario, host_ips, start, logical_start) = ac0_compressed_test_inputs();
+        let tm = ac0_compressed_time_map(&scenario, start, logical_start);
+        let meta = build(
+            "ac-0-compressed.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            logical_start,
+            &[],
+        )
+        .unwrap();
+        // generated_at carries the real wall-clock at run start, not the
+        // scenario's logical start_at.
+        assert_eq!(meta.generated_at, "2026-01-15T09:00:00Z");
+        assert_ne!(meta.generated_at, "2026-05-03T00:00:00Z");
+    }
+
+    #[test]
+    fn build_meta_compressed_actual_start_equals_start_at() {
+        let (scenario, host_ips, start, logical_start) = ac0_compressed_test_inputs();
+        let tm = ac0_compressed_time_map(&scenario, start, logical_start);
+        let meta = build(
+            "ac-0-compressed.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            logical_start,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(meta.duration.actual_start, "2026-05-03T00:00:00Z");
+    }
+
+    #[test]
+    fn build_meta_compressed_total_is_logical_duration() {
+        let (scenario, host_ips, start, logical_start) = ac0_compressed_test_inputs();
+        let tm = ac0_compressed_time_map(&scenario, start, logical_start);
+        let meta = build(
+            "ac-0-compressed.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            logical_start,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(meta.duration.total, "14d");
+    }
+
+    #[test]
+    fn build_meta_compressed_actual_end_within_logical_window() {
+        let (scenario, host_ips, start, logical_start) = ac0_compressed_test_inputs();
+        let tm = ac0_compressed_time_map(&scenario, start, logical_start);
+        // Caller-aggregated end: 10 logical days past start_at — within
+        // the second activity's anchor window for a typical normal run.
+        let aggregated_end = logical_start + Duration::try_days(10).unwrap();
+        let meta = build(
+            "ac-0-compressed.scenario.yaml",
+            &scenario,
+            &host_ips,
+            &tm,
+            aggregated_end,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(meta.duration.actual_end, "2026-05-13T00:00:00Z");
+
+        let parsed_end = DateTime::parse_from_rfc3339(&meta.duration.actual_end)
+            .unwrap()
+            .with_timezone(&Utc);
+        let parsed_start = DateTime::parse_from_rfc3339(&meta.duration.actual_start)
+            .unwrap()
+            .with_timezone(&Utc);
+        let upper = logical_start + Duration::try_days(14).unwrap();
+        assert!(parsed_end >= parsed_start && parsed_end <= upper);
+    }
 }

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -1885,6 +1885,23 @@ activities:
         assert_eq!(s.activities.attack.len(), 2);
     }
 
+    #[test]
+    fn load_ac0_compressed_from_file() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scenarios")
+            .join("ac-0-compressed.scenario.yaml");
+        let s = load(&path).unwrap();
+        assert_eq!(s.metadata.name, "ac-0-compressed");
+        assert_eq!(s.duration, "5m");
+        assert_eq!(s.logical_duration.as_deref(), Some("14d"));
+        let start_at = s.start_at.expect("start_at should parse");
+        assert_eq!(start_at.to_rfc3339(), "2026-05-03T00:00:00+00:00");
+        assert_eq!(s.activities.normal.len(), 1);
+        assert_eq!(s.activities.attack.len(), 1);
+        assert_eq!(s.activities.normal[0].start_offset, "5d");
+        assert_eq!(s.activities.attack[0].start_offset, "10d");
+    }
+
     // ── Vantage point ────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `scenarios/ac-0-compressed.scenario.yaml` — same infrastructure and commands as `ac-0`, but with `start_at: 2026-05-03T00:00:00Z`, `duration: 5m`, and `logical_duration: 14d` (scale_factor 4032). The two activities are spaced 5d / 10d in logical time so anchor windows stay overlap-free even on slow CI runners.
- Adds four `meta.rs` unit tests around a new `ac0_compressed_test_inputs()` helper that round-trip the scenario through a non-identity `TimeMap` and pin the four `meta.json` invariants from the issue (§2).
- Adds a `scenario.rs` smoke test that loads the new scenario file and verifies its parsed shape.
- Adds an `ac0-compressed-pipeline` CI job that runs `generate` + `validate` and shells out to three Python checkers under `.github/scripts/`:
  - `check_ac0_compressed_meta.py` — asserts `duration.actual_start`, `duration.total`, and that `actual_end` falls strictly inside `(actual_start, start_at + 14d]`.
  - `check_ac0_compressed_gt.py` — asserts exactly two manifest records, that their `start` offsets land near 5d / 10d past `start_at`, and that the inter-session gap is ~5d (10-minute logical tolerance for scheduler/command jitter).
  - `check_ac0_compressed_pcap.py` — asserts microsecond pcap magic, non-zero packet count, all packet timestamps `>= start_at`, and monotonic non-decreasing ordering.
- Adds `__pycache__/` to `.gitignore` so the helper scripts' caches stay out of the tree.

Existing committed scenarios and the `build_meta_matches_ac0_reference` reference test are untouched.

Closes #66

## Test plan

- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] `cargo test --bin multifold` passes, including:
  - [x] `meta::tests::build_meta_compressed_generated_at_is_real_not_logical`
  - [x] `meta::tests::build_meta_compressed_actual_start_equals_start_at`
  - [x] `meta::tests::build_meta_compressed_total_is_logical_duration`
  - [x] `meta::tests::build_meta_compressed_actual_end_within_logical_window`
  - [x] `scenario::tests::load_ac0_compressed_from_file`
  - [x] `meta::tests::build_meta_matches_ac0_reference` still passes (no regression).
- [x] The new `ac0-compressed-pipeline` CI job runs end-to-end and:
  - [x] `cargo run --release -- generate -s scenarios/ac-0-compressed.scenario.yaml -o ac0c-bundle` succeeds.
  - [x] `cargo run --release -- validate -b ac0c-bundle` succeeds.
  - [x] `check_ac0_compressed_meta.py` passes against the generated `meta.json`.
  - [x] `check_ac0_compressed_gt.py` passes against the generated `manifest.jsonl`.
  - [x] `check_ac0_compressed_pcap.py` passes against the generated `net/lan.pcap`.
- [x] The existing `ac0-pipeline` CI job continues to pass unchanged.
