### PR TITLE
Add a Markdown lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Ungated and standalone, matching `aicers/roxyd` and `aicers/agentcoop`. Kept
+  # out of `check` so a clippy failure cannot hide the Markdown result, and so
+  # the lint survives if the expensive jobs are ever put behind a path filter.
+  markdown:
+    name: Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          globs: "**/*.md"
+
   check:
     name: Quality Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #90.

## What was wrong

Nothing checked the Markdown in this repository. `AGENTS.md` and `CLAUDE.md` were unlinted, and every sibling repository in the organization — `aicers/roxyd`, `aicers/agentcoop`, `aicers/bootroot`, `aicers/crusher`, `aicers/giganto`, the `review-*` repositories — lints its own.

## The change

A standalone `markdown` job (display name `Markdown`) with a recursive glob, matching the shape `aicers/roxyd` and `aicers/agentcoop` use.

Standalone rather than a step inside `check`, for two reasons: a clippy failure should not hide the Markdown result, and the lint should survive if the expensive jobs are ever put behind a path filter — a docs-only change is exactly the change that needs it.

No `.markdownlint-cli2.yaml` is added. Stock defaults pass as-is; a config can be added later if a rule proves too strict, rather than pre-emptively.

## Verification

- `markdownlint-cli2@0.23.2` — the version `@v24` pins — run recursively against `main` locally reports **0 issues** across both files with stock defaults.
- `actionlint` (with shellcheck) is clean.
- `main` has no branch protection, so no required-check change is needed.

## Relationship to the other open pull request

There is a separate pull request in this repository scoping the CI triggers. The two touch different parts of `ci.yml` and were tested to merge cleanly in either order (`git merge-tree`, no conflict).

## Out of scope

- Adding a markdownlint config file.
- CI triggers and path filtering.
