### PR TITLE
Carry the organisation-wide MD024 baseline

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,11 @@
+globs:
+  - "**/*.md"
+ignores:
+  - "node_modules/**"
+  - ".github/**"
+config:
+  # Organisation-wide baseline: CHANGELOG files in Keep a Changelog format
+  # repeat `Added` and `Fixed` under every version. `siblings_only` allows
+  # that while still catching genuine duplicates inside one section.
+  MD024:
+    siblings_only: true


### PR DESCRIPTION
Closes #92

Brings this repository onto the shared `MD024: siblings_only` setting that 24 of the organisation's 27 linted repositories already carry. It exists for `CHANGELOG.md` files in Keep a Changelog format, where every version repeats `Added` and `Fixed`; `siblings_only` permits that while still catching genuine duplicates inside one section.

MD024 reports nothing in this repository today — there is no changelog here. This is a baseline change rather than a fix, so that the setting is identical everywhere.

**Verification**: markdownlint-cli2 0.23.2 with the new configuration — `0 issues`, exit 0.