### PR TITLE
Add a CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+This file documents recent notable changes to this project. The format of this
+file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+[Unreleased]: https://github.com/aicers/multifold/commits/main


### PR DESCRIPTION
Closes #95.

The header is byte-identical to the one `review-web`, `review-database`, `bootroot`, `aimer`, and `agentcoop` already carry — copied from `review-web` rather than retyped, so it does not drift from them on wording, on the Keep a Changelog version, or on line breaks.

No entries. Inventing a history for work already shipped would be a record nobody wrote; `## [Unreleased]` is where the next real change goes.

This is a prerequisite for taking the `changelog` block from `aicers/agent-instructions`: the block is the shared rule set for maintaining this file, and upstream `STYLE.md` asks the block to follow the file rather than lead it. Onboarding is tracked in aicers/agent-instructions#22.
